### PR TITLE
map() example requires magrittr 1.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,6 @@ Description: A FP package for R in the spirit of underscore.js
 License: GPL-3
 LazyData: true
 Imports:
-    magrittr
+    magrittr (>= 1.5)
 Suggests:
     testthat


### PR DESCRIPTION
The last example in `map` does not work with magrittr 1.0.1. It throws an error at

``` r
mtcars %>%
  split(.$cyl)
```

You either need `%>%` from magrittr 1.5 or do

``` r
mtcars %>%
  split(mtcars$cyl)
```
