### PR TITLE
Enhancements to flatten()

### DIFF
--- a/R/flatten.R
+++ b/R/flatten.R
@@ -3,8 +3,13 @@
 #' This is a wrapper for \code{\link{unlist}()} that defaults to
 #' \code{recursive = FALSE}.
 #'
+#' When \code{.unname} is \code{TRUE} and \code{.recursive} is
+#' \code{FALSE}, only the names of \code{.x} are removed, leaving the
+#' inner lists intact. But if \code{.recursive} is \code{TRUE}, the
+#' names of all inner lists are also removed.
 #' @param .x A list of flatten
 #' @param .recursive Recursively flatten list components?
+#' @param .unname Remove names before flattening?
 #' @export
 #' @examples
 #' x <- rerun(10, sample(5))
@@ -14,6 +19,12 @@
 #' x %>% map(~ .[1]) %>% flatten()
 #' # But it's better to use map_v
 #' x %>% map_v(~ .[1])
-flatten <- function(.x, .recursive = FALSE) {
-  unlist(.x, recursive = .recursive)
+flatten <- function(.x, .recursive = FALSE, .unname = FALSE) {
+  use_names <- TRUE
+  if (.unname && .recursive) {
+    use_names <- FALSE
+  } else if (.unname && !.recursive) {
+    names(.x) <- NULL
+  }
+  unlist(.x, recursive = .recursive, use.names = use_names)
 }

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -26,5 +26,5 @@ flatten <- function(.x, .recursive = FALSE, .unname = FALSE) {
   } else if (.unname && !.recursive) {
     names(.x) <- NULL
   }
-  unlist(.x, recursive = .recursive, use.names = use_names)
+  unlist(.x, recursive = .recursive, use.names = use_names) %||% list()
 }

--- a/man/flatten.Rd
+++ b/man/flatten.Rd
@@ -4,16 +4,24 @@
 \alias{flatten}
 \title{Flatten a list of lists into a list.}
 \usage{
-flatten(.x, .recursive = FALSE)
+flatten(.x, .recursive = FALSE, .unname = FALSE)
 }
 \arguments{
 \item{.x}{A list of flatten}
 
 \item{.recursive}{Recursively flatten list components?}
+
+\item{.unname}{Remove names before flattening?}
 }
 \description{
 This is a wrapper for \code{\link{unlist}()} that defaults to
 \code{recursive = FALSE}.
+}
+\details{
+When \code{.unname} is \code{TRUE} and \code{.recursive} is
+\code{FALSE}, only the names of \code{.x} are removed, leaving the
+inner lists intact. But if \code{.recursive} is \code{TRUE}, the
+names of all inner lists are also removed.
 }
 \examples{
 x <- rerun(10, sample(5))


### PR DESCRIPTION
This adds a `.unname` argument to `flatten()`. The goal is to avoid parasite names such as in the following example:
```{r}
l <- list(A = list(a = 1, b = 2), B = list(c = 3, d = 4))
flatten(l) %>% str()
## List of 4
##  $ A.a: num 1
##  $ A.b: num 2
##  $ B.c: num 3
##  $ B.d: num 4
```

With `.unname = TRUE`, this becomes:
```{r}
flatten(l, .unname = TRUE) %>% str()
## List of 4
##  $ a: num 1
##  $ b: num 2
##  $ c: num 3
##  $ d: num 4
```

The unnaming behavior differs as a function of `.recursive`: with recursive flattening, `unlist()` is called with `use.names = FALSE`. In the non-recursive case, only the names of the outer list are zapped.

This also makes `flatten(list())` return an empty list instead of `NULL` as suggested in #58.

