### PR TITLE
map_n() fixes

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -154,9 +154,8 @@ map3 <- function(.x, .y, .z, .f, ...) {
 #' @rdname map2
 map_n <- function(.l, .f, ...) {
   .f <- as_function(.f)
-  f <- partial(.f, ..., .first = FALSE)
   args <- recycle_args(.l)
-  do.call("Map", c(list(quote(f)), args))
+  do.call("mapply", c(list(quote(.f)), args, MoreArgs = quote(list(...)), SIMPLIFY = FALSE))
 }
 
 

--- a/R/map.R
+++ b/R/map.R
@@ -155,7 +155,10 @@ map3 <- function(.x, .y, .z, .f, ...) {
 map_n <- function(.l, .f, ...) {
   .f <- as_function(.f)
   args <- recycle_args(.l)
-  do.call("mapply", c(list(quote(.f)), args, MoreArgs = quote(list(...)), SIMPLIFY = FALSE))
+  do.call("mapply", c(
+    FUN = list(quote(.f)), args, MoreArgs = quote(list(...)),
+    SIMPLIFY = FALSE, USE.NAMES = FALSE
+  ))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,6 +52,9 @@ as_function <- function(f) {
 
 output_hook <- function(out, x) {
   if (is.data.frame(x)) {
+    if (is.null(names(out))) {
+      names(out) <- names(x)
+    }
     dplyr::as_data_frame(out)
   } else {
     out

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -23,14 +23,8 @@ test_that("map2() and map3() return a data frame when given one", {
 test_that("map_n() is not vectorized over additional arguments (see #54)", {
   f <- function(x, y, zs) zs
   actual <- list(1:3, 1:3)
-  alleged <- map2(1:2, 1:2, f, zs = 1:3)
-  expect_equal(actual, alleged)
-})
-
-test_that("map_n() works with unnamed additional arguments", {
-  # Relies on map_n() using partial() with .first set to FALSE
-  f <- function(x, y, zs) zs
-  actual <- list(1:3, 1:3)
-  alleged <- map2(1:2, 1:2, f, 1:3)
-  expect_equal(actual, alleged)
+  alleged1 <- map2(1:2, 1:2, f, zs = 1:3)
+  alleged2 <- map2(1:2, 1:2, f, 1:3)
+  expect_equal(actual, alleged1)
+  expect_equal(actual, alleged2)
 })


### PR DESCRIPTION
Hello,

Since #59 is stuck, I cherry-picked the corrective commit of @sumprain.
I also set `USE.NAMES = FALSE` so that `map_n()` always returns an unnamed list as discussed in #64.

However this last change made `map2()` and `map3()` incompatible with data frames because we need a named list to coerce back to data frame. This is one case where it makes sense to name the output after the names of the first argument so I adjusted `output_hook()` to take care of this.