### PR TITLE
Added predicate function operators for creating predicate function

### DIFF
--- a/R/andify.R
+++ b/R/andify.R
@@ -1,0 +1,40 @@
+#' Predicate function operator that creates new predicate functions linked by the && operator.
+#'
+#' @param ... n functions to apply in order from left to right.
+#' @return A predicate function linked by the && operator.
+#' @family predicate function operators
+#' @seealso \code{\link{Orify}} to create new predicate functions linked by the || operator.
+#' @examples
+#' # Examples
+#' is_numeric <- is.numeric
+#' is_even <- function(x) x %% 2 == 0
+#' greater_than_10 <- function(x) x > 10
+#' less_than_100 <- function(x) x < 100
+#' even_number_between_10_and_100 <-
+#' andify(is_numeric, is_even, greater_than_10, less_than_100)
+#' even_number_between_10_and_100(8) # FALSE
+#' even_number_between_10_and_100(9) # FALSE
+#' even_number_between_10_and_100(10) # FALSE
+#' even_number_between_10_and_100(11) # FALSE
+#' even_number_between_10_and_100(12) # TRUE
+#' even_number_between_10_and_100(49) # FALSE
+#' even_number_between_10_and_100(50) # TRUE
+#' even_number_between_10_and_100(100) # FALSE
+#' even_number_between_10_and_100(101) # FALSE
+#' even_number_between_10_and_100(102) # FALSE
+#' @export
+andify <- function(...) {
+  fs <- lapply(list(...), match.fun)
+  if (length(fs) == 0) stop("Must pass at least one argument.")
+  first <- fs[[1]]
+  rest <- fs[-1]
+
+  function(...) {
+    out <- first(...)
+    for (f in rest) {
+      if (!out) return(FALSE)
+      out <- `&&`(out, f(...))
+    }
+    out
+  }
+}

--- a/R/orify.R
+++ b/R/orify.R
@@ -1,0 +1,27 @@
+#' Predicate function operator that creates new predicate functions linked by the || operator.
+#'
+#' @param ... n functions to apply in order from left to right
+#' @return A predicate function linked by the || operator.
+#' @family predicate function operators
+#' @seealso \code{\link{Andify}} to create new predicate functions linked by the && operator.
+#' @examples
+#' # Examples
+#' is_character_or_factor <- orify(is.character, is.factor)
+#' is_character_or_factor(letters) # TRUE
+#' is_character_or_factor(factor(state.abb)) # TRUE
+#' is_character_or_factor(1:100) # FALSE
+#' @export
+orify <- function(...) {
+  fs <- lapply(list(...), match.fun)
+  first <- fs[[1]]
+  rest <- fs[-1]
+
+  function(...) {
+    out <- first(...)
+    for (f in rest) {
+      if (out) return(TRUE)
+      out <- `||`(out, f(...))
+    }
+    out
+  }
+}

--- a/tests/testthat/test-andify.R
+++ b/tests/testthat/test-andify.R
@@ -1,0 +1,33 @@
+library(functools)
+context("andify()")
+
+is_numeric <- is.numeric
+is_even <- function(x) x %% 2 == 0
+greater_than_10 <- function(x) x > 10
+less_than_100 <- function(x) x < 100
+even_number_between_10_and_100 <-
+  andify(is_numeric, is_even, greater_than_10, less_than_100)
+
+test_that("Produces the correct output.", {
+  expect_equal(andify(is.numeric, function(x) x < 20)(20), FALSE)
+  expect_equal(andify(is.numeric, function(x) x < 20)(19), TRUE)
+  expect_equal(even_number_between_10_and_100(8), FALSE)
+  expect_equal(even_number_between_10_and_100(9), FALSE)
+  expect_equal(even_number_between_10_and_100(10), FALSE)
+  expect_equal(even_number_between_10_and_100(11), FALSE)
+  expect_equal(even_number_between_10_and_100(12), TRUE)
+  expect_equal(even_number_between_10_and_100(49), FALSE)
+  expect_equal(even_number_between_10_and_100(50), TRUE)
+  expect_equal(even_number_between_10_and_100(100), FALSE)
+  expect_equal(even_number_between_10_and_100(101), FALSE)
+  expect_equal(even_number_between_10_and_100(102), FALSE)
+})
+
+test_that("Produces the correct output type.", {
+  expect_is(andify(is.numeric, function(x) x < 20), "function")
+  expect_is(even_number_between_10_and_100, "function")
+})
+
+test_that("Produces the correct errors.", {
+  expect_error(andify())
+})

--- a/tests/testthat/test-orify.R
+++ b/tests/testthat/test-orify.R
@@ -1,0 +1,17 @@
+library(functools)
+context("Orify()")
+
+is_character_or_factor <- Orify(is.character, is.factor)
+test_that("Produces the correct output.", {
+  expect_equal(is_character_or_factor(letters), TRUE)
+  expect_equal(is_character_or_factor(factor(state.abb)), TRUE)
+  expect_equal(is_character_or_factor(1:100), FALSE)
+})
+
+test_that("Produces the correct output type.", {
+  expect_is(is_character_or_factor, "function")
+})
+
+test_that("Produces the correct errors.", {
+  expect_error(Orify())
+})


### PR DESCRIPTION
These functions make it easy to combine functions and evaluate an option using && and ||. I'm unsure if you already have similar functions but I've found them useful. For example:

```R
is_factor_or_character <- orify(is.factor, is.character)
is_factor_or_character(letters) # TRUE
is_factor_or_character(1:10) # FALSE
is_factor_or_character(factor(letters)) # TRUE
```

```R
between_0_and_10 <- andify(function(x) x > 0, function(x) x < 10)
between_0_and_10 (0) # FALSE
between_0_and_10 (5) # TRUE
between_0_and_10 (10) # FALSE
```

