### PR TITLE
Allow skipping of shallow branches

### DIFF
--- a/R/at-depth.R
+++ b/R/at-depth.R
@@ -59,7 +59,9 @@
 #' # Here we have a list with one branch shorter than the other.
 #' l3 <- l2
 #' l3[[1]] <- c(1, 2)
-#' print(try(l3 %>% at_depth(3, map_n, paste, sep = " / "), silent = TRUE))
+#' \dontrun{
+#' l3 %>% at_depth(3, map_n, paste, sep = " / ")
+#' }
 #' l3 %>% at_depth(3, map_n, paste, sep = " / ", .skip = TRUE)
 at_depth <- function(.x, .depth, .f, ..., .skip = FALSE) {
   .f <- as_function(.f)

--- a/man/at_depth.Rd
+++ b/man/at_depth.Rd
@@ -4,7 +4,7 @@
 \alias{at_depth}
 \title{Map a function over lower levels of a nested list}
 \usage{
-at_depth(.x, .depth, .f, ...)
+at_depth(.x, .depth, .f, ..., .skip = FALSE)
 }
 \arguments{
 \item{.x}{A deep list}
@@ -23,6 +23,8 @@ at_depth(.x, .depth, .f, ...)
   \code{function(x) x[["y"]]}.}
 
 \item{...}{Additional arguments passed on to \code{.f}.}
+
+\item{.skip}{Whether to skip branches that are too shallow.}
 }
 \description{
 \code{at_depth()} maps a function on lower levels of nested
@@ -76,5 +78,11 @@ l2 <- list(
 # elements of the objects at the second level. paste() is thus
 # effectively mapped at level 3.
 l2 \%>\% at_depth(2, map_n, paste, sep = " / ")
+
+# Here we have a list with one branch shorter than the other.
+l3 <- l2
+l3[[1]] <- c(1, 2)
+print(try(l3 \%>\% at_depth(3, map_n, paste, sep = " / "), silent = TRUE))
+l3 \%>\% at_depth(3, map_n, paste, sep = " / ", .skip = TRUE)
 }
 


### PR DESCRIPTION
This creates a new parameter `.skip = FALSE` that tells `at_depth` not to modify branches that are shallower than `depth`.  Instead, the shallow branch is returned as-is, among the modified branches.

Currently, any branch of a nested list that is shallower than `depth` causes `at_depth` to fail with `"List not deep enough"`.

```r
l3 <- list(
  obj1 = 1:2,
  obj2 = list(
    prop1 = list(c(10, 20), c(30, 40))
  )
)

l3 %>% at_depth(3, map_n, paste, sep = " / ")
```

```
## Error: List not deep enough
```

```r
l3 %>% at_depth(3, map_n, paste, sep = " / ", .skip = TRUE)
```

```
## $obj1
## [1] 1 2
## 
## $obj2
## $obj2$prop1
## $obj2$prop1[[1]]
## $obj2$prop1[[1]][[1]]
## [1] "10 / 20"
## 
## 
## $obj2$prop1[[2]]
## $obj2$prop1[[2]][[1]]
## [1] "30 / 40"
```