### PR TITLE
test recycle_args and fix apparent bug?

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -94,7 +94,7 @@ recycle_args <- function(args) {
   lengths <- map_int(args, length)
   n <- max(lengths)
 
-  stopifnot(all(lengths == 1L || lengths == n))
+  stopifnot(all(lengths == 1L | lengths == n))
   to_recycle <- lengths == 1L
   args[to_recycle] <- lapply(args[to_recycle], function(x) rep.int(x, n))
   args

--- a/tests/testthat/test-recycle_args.R
+++ b/tests/testthat/test-recycle_args.R
@@ -1,0 +1,22 @@
+context("recycle_args")
+
+test_that("rejects uneven lengths", {
+  args <- list(1, c(1:2), NULL)
+  expect_error(purrr:::recycle_args(args), "lengths == 1L \\| lengths == n")
+})
+
+
+test_that("recycles single values and preserves longer ones", {
+  args <- list(1, 1:12,  month.name, "a")
+  recycled <- purrr:::recycle_args(args)
+
+  expect_equal(recycled[[1]], rep(1, 12))
+  expect_equal(recycled[[2]], 1:12)
+  expect_equal(recycled[[3]], month.name)
+  expect_equal(recycled[[4]], rep("a", 12))
+})
+
+test_that("will not recycle non-vectors", {
+  args <- list(1:12,  identity)
+  expect_error(purrr:::recycle_args(args), "replicate an object of type 'closure'")
+})


### PR DESCRIPTION
This package looks fantastic.  I decided to poke around with some of the code to learn more about functional programming in R and I found some behavior that should probably be changed.

In the master branch, the use of `||` in `recycle_args` leads R to only check the first element of `lengths`. I changed `||` to `|` and added some tests.  Hope this is useful.