### PR TITLE
Fixed a typo in the man page for partial.RD

### DIFF
--- a/R/partial.R
+++ b/R/partial.R
@@ -30,7 +30,7 @@
 #' compact1 <- function(x) discard(x, is.null)
 #'
 #' # we can write:
-#' compact2 <- partial(discard, .f = is.null)
+#' compact2 <- partial(discard, .p = is.null)
 #'
 #' # and the generated source code is very similar to what we made by hand
 #' compact1

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -70,7 +70,7 @@ a data frame by row-binding the individual elements.
 Note that \code{map()} understands data frames, including grouped
 data frames. It can be much faster than
 \code{\link[dplyr:summarise_each]{mutate_each()}} when your data frame has many
-columns. However, \code{map()}ll be slower for the more common case of many
+columns. However, \code{map()} will be slower for the more common case of many
 groups with functions that dplyr knows how to translate to C++.
 }
 \examples{

--- a/man/partial.Rd
+++ b/man/partial.Rd
@@ -43,7 +43,7 @@ if you weren't using \code{partial}.
 compact1 <- function(x) discard(x, is.null)
 
 # we can write:
-compact2 <- partial(discard, .f = is.null)
+compact2 <- partial(discard, .p = is.null)
 
 # and the generated source code is very similar to what we made by hand
 compact1


### PR DESCRIPTION
Under "Examples", it gave the code as: `compact2 <- partial(discard, .f = is.null) `
but the named argument for `discard` which `partial` is filling is not `.f`, but `.p`.  
Running the function `compact2` (e.g. `compact2(c(1,2,NULL,4)`) as the code was previously produces an error.