### PR TITLE
Deprecate dataframe-based mapping functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # purrr 0.2.2.9000
 
+* All data-frame based mappers have been deprecated in favour of new
+  functions and idioms in the tidyverse.
+
+    * Mapping a function to each column of a data frame should now be
+      handled with the colwise mutating and summarising operations in
+      dplyr instead of `dmap()`. These are the verbs with suffix
+      `_all()`, `_at()` and `_if()`, such as `mutate_all()` or
+      `summarise_if()`. Note that this means the output of `.f` should
+      conform to the requirements of dplyr operations: same length as
+      the input for mutating operations, and length 1 for summarising
+      operations.
+
+    * Inovking a function row by row with the columns of a data frame
+      as arguments should be done with `pmap()` followed by
+      `dplyr::as_dataframe()` instead of `map_rows()`.
+
+    * Mapping rowwise slices of a data frame with `by_row()` is
+      deprecated in favour of a combination of tidyverse functions.
+      First use `tidyr::nest()` to create a list-column containing
+      groupwise data frames. Then use `dplyr::mutate()` to operate on
+      this list-column. Typically you will want to apply a function on
+      each element (nested data frame) of this list-column with
+      `purrr::map()`.
+
 * `cross_n()` has been renamed to `cross()`. The `_n` suffix was
   removed for consistency with `pmap()` (originally called `map_n()`
   at the start of the project) and `transpose()` (originally called

--- a/R/dmap.R
+++ b/R/dmap.R
@@ -23,6 +23,8 @@
 #' # with 'rows' collation of results:
 #' sliced_df %>% by_slice(dmap, mean, .collate = "rows")
 dmap <- function(.d, .f, ...) {
+  message("dmap() is deprecated. Please use the new colwise family in dplyr.\n",
+    "E.g., summarise_all(), mutate_all(), etc.")
   .f <- as_function(.f, ...)
   if (dplyr::is.grouped_df(.d)) {
     sliced_dmap(.d, .f, ...)
@@ -46,6 +48,8 @@ sliced_dmap <- function(.d, .f, ...) {
 #' @rdname dmap
 #' @export
 dmap_at <- function(.d, .at, .f, ...) {
+  message("dmap_at() is deprecated. Please use the new colwise family in dplyr.\n",
+    "E.g., summarise_at(), mutate_at(), etc.")
   sel <- inv_which(.d, .at)
   partial_dmap(.d, sel, .f, ...)
 }
@@ -53,6 +57,8 @@ dmap_at <- function(.d, .at, .f, ...) {
 #' @rdname dmap
 #' @export
 dmap_if <- function(.d, .p, .f, ...) {
+  message("dmap_if() is deprecated. Please use the new colwise family in dplyr.\n",
+    "E.g., summarise_if(), mutate_if(), etc.")
   sel <- map_lgl(.d, .p)
   partial_dmap(.d, sel, .f, ...)
 }

--- a/R/rows.R
+++ b/R/rows.R
@@ -70,6 +70,8 @@
 #'   map(coef)
 by_slice <- function(.d, ..f, ..., .collate = c("list", "rows", "cols"),
                      .to = ".out", .labels = TRUE) {
+  message("by_slice() is deprecated. Please use the new colwise family in dplyr.\n",
+    "E.g., summarise_all(), mutate_all(), etc.")
   ..f <- as_rows_function(..f)
   if (!dplyr::is.grouped_df(.d)) {
     stop(".d must be a sliced data frame", call. = FALSE)
@@ -181,6 +183,8 @@ set_sliced_env <- function(df, labels, collate, to, env, x_name) {
 #' mtcars[1:2] %>% by_row(function(x) 1:5, .collate = "cols")
 by_row <- function(.d, ..f, ..., .collate = c("list", "rows", "cols"),
                    .to = ".out", .labels = TRUE) {
+  message("`by_row()` is deprecated; please use a combination of:\n",
+    "tidyr::nest(); dplyr::mutate(); purrr::map()")
   check_df_consistency(.d)
   if (nrow(.d) < 1) {
     return(.d)
@@ -220,6 +224,7 @@ check_df_consistency <- function(.d) {
 #' @export
 invoke_rows <- function(.f, .d, ..., .collate = c("list", "rows", "cols"),
                         .to = ".out", .labels = TRUE) {
+  message("`invoke_rows()` is deprecated; please use `pmap()` instead.")
   check_df_consistency(.d)
   .collate <- match.arg(.collate)
 
@@ -234,8 +239,7 @@ invoke_rows <- function(.f, .d, ..., .collate = c("list", "rows", "cols"),
 #' @usage NULL
 #' @rdname by_row
 map_rows <- function(.d, .f, ..., .labels = TRUE) {
-  message("`map_rows()` is deprecated; please use `invoke_rows()` instead.",
-    call. = FALSE)
+  message("`map_rows()` is deprecated; please use `pmap()` instead.")
   invoke_rows(.f, .d, ..., .labels = .labels)
 }
 
@@ -255,6 +259,7 @@ map_rows <- function(.d, .f, ..., .labels = TRUE) {
 #' @seealso \code{\link{by_slice}()} and \code{\link[dplyr]{group_by}()}
 #' @export
 slice_rows <- function(.d, .cols = NULL) {
+  message("`slice_rows()` is deprecated; please use `dplyr::group_by()` instead.")
   stopifnot(is.data.frame(.d))
   if (is.null(.cols)) {
     return(unslice(.d))
@@ -270,5 +275,6 @@ slice_rows <- function(.d, .cols = NULL) {
 #' @rdname slice_rows
 #' @export
 unslice <- function(.d) {
+  message("`unslice()` is deprecated; please use `dplyr::ungroup()` instead.")
   dplyr::group_by_(.d, .dots = list())
 }


### PR DESCRIPTION
Deprecation of rows-based functions now that we have the new mapping functions in dplyr and the nest() / mutate() / map() idiom.

One use case that does not have any equivalent in dplyr is when the output is within the range `c(1, nrow(df))`. For example:

```{r}
dmap(mtcars, summary)
```

This can be worked around, for example here we'd do

```{r}
mtcars %>% map(summary) %>% as_data_frame()
```

However a new dplyr family of verbs for variable-length output may be useful. It could be called `condense()`.

- Like `summarise()` it would discard all input columns except for the grouping variables. This allows the output to have a different number of rows than the input.

- Unlike `summarise()`, it would not require length 1 results and would only check for equal length within group. Grouping columns would be recycled to these lengths.

Ungrouped data frame: check squared constraint

```{r}
mtcars %>% condense(col = 1:5, other = 5:1)
#> # A tibble: 5 x 2
#>     col other
#>   <int> <int>
#> 1     1     5
#> 2     2     4
#> 3     3     3
#> 4     4     2
#> 5     5     1

mtcars %>% condense(col = 1:5, other = 2:1)
#> Error: results must have same length
```

This gives us immediately:

```{r}
mtcars %>% condense_all(summary)
#> # A tibble: 6 x 11
#>           mpg         cyl        disp          hp        drat
#>   <S3: table> <S3: table> <S3: table> <S3: table> <S3: table>
#> 1        10.4        4.00        71.1        52.0        2.76
#> 2        15.4        4.00       121.0        96.5        3.08
#> 3        19.2        6.00       196.0       123.0        3.70
#> 4        20.1        6.19       231.0       147.0        3.60
#> 5        22.8        8.00       326.0       180.0        3.92
#> 6        33.9        8.00       472.0       335.0        4.93
#> # ... with 6 more variables: wt <S3: table>, qsec <S3: table>, vs <S3:
#> #   table>, am <S3: table>, gear <S3: table>, carb <S3: table>
```

For a grouped data frame, we'd check the square constrain within groups:

```{r}
grouped <- mtcars %>% group_by(am)

grouped %>%
  condense(
    col = rep(mean(cyl), times = round(mean(cyl))),
    other = rep(length(col), length(col))
  )
#> # A tibble: 12 x 3
#>       am   col other
#>    <dbl> <dbl> <dbl>
#> 1      0  6.95     7
#> 2      0  6.95     7
#> 3      0  6.95     7
#> 4      0  6.95     7
#> 5      0  6.95     7
#> 6      0  6.95     7
#> 7      0  6.95     7
#> 8      1  5.08     5
#> 9      1  5.08     5
#> 10     1  5.08     5
#> 11     1  5.08     5
#> 12     1  5.08     5

grouped %>%
  condense(
    col = rep(mean(cyl), times = round(mean(cyl))),
    other = rep(length(col), length(col) - 1)
  )
#> Error: results must have same length within groups
```

Relevant discussion: hadley/dplyr#154
