### PR TITLE
Update compact function

### DIFF
--- a/R/keep.R
+++ b/R/keep.R
@@ -44,5 +44,5 @@ discard <- function(.x, .p, ...) {
 #' @rdname keep
 compact <- function(.x, .p = identity) {
   .f <- as_function(.p)
-  .x %>% discard(function(x) is_empty(.p(x)))
+  .x %>% discard(function(x) is_empty(.f(x)))
 }


### PR DESCRIPTION
This allows for more flexible function specification in the arguments. Otherwise, I think it was a typo to define `.f` and then not use it.