### PR TITLE
Add argument to is_formula() to test one- or two-sidedness

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -293,8 +293,28 @@ is_empty <- function(x) length(x) == 0
 #' Is a formula?
 #'
 #' @inheritParams is_empty
+#' @param has_lhs If \code{TRUE}, tests that the formula
+#'   is two-sided. If \code{FALSE}, tests that the
+#'   formula is one sided. If \code{NULL} or \code{NA},
+#'   does not test for the sidedness of the formula.
 #' @export
 #' @examples
 #' x <- disp ~ am
 #' is_formula(x)
-is_formula <- function(x) inherits(x, "formula")
+#' is_formula(x, has_lhs = TRUE)
+#' is_formula(x, has_lhs = FALSE)
+#' y <- ~ am
+#' is_formula(y)
+#' is_formula(y, has_lhs = TRUE)
+#' is_formula(y, has_lhs = FALSE)
+is_formula <- function(x, has_lhs = NULL) {
+  f <- inherits(x, "formula")
+  if (f && !is.null(has_lhs) && !is.na(has_lhs)) {
+    f <- if (has_lhs) {
+      length(x) == 3
+    } else {
+      length(x) == 2
+    }
+  }
+  f
+}

--- a/man/is_formula.Rd
+++ b/man/is_formula.Rd
@@ -4,10 +4,15 @@
 \alias{is_formula}
 \title{Is a formula?}
 \usage{
-is_formula(x)
+is_formula(x, has_lhs = NULL)
 }
 \arguments{
 \item{x}{object to test}
+
+\item{has_lhs}{If \code{TRUE}, tests that the formula
+is two-sided. If \code{FALSE}, tests that the
+formula is one sided. If \code{NULL} or \code{NA},
+does not test for the sidedness of the formula.}
 }
 \description{
 Is a formula?
@@ -15,5 +20,10 @@ Is a formula?
 \examples{
 x <- disp ~ am
 is_formula(x)
+is_formula(x, has_lhs = TRUE)
+is_formula(x, has_lhs = FALSE)
+y <- ~ am
+is_formula(y)
+is_formula(y, has_lhs = TRUE)
+is_formula(y, has_lhs = FALSE)
 }
-

--- a/tests/testthat/test-is_formula.R
+++ b/tests/testthat/test-is_formula.R
@@ -1,0 +1,17 @@
+context("is_formula")
+
+test_that("is_formula works as expected", {
+  expect_true(is_formula(~ x + y))
+  expect_false(is_formula(1))
+  expect_false(is_formula(quote(x + y)))
+  # one-sided formula
+  expect_true(is_formula(~ x + y, has_lhs = NA))
+  expect_true(is_formula(~ x + y, has_lhs = NULL))
+  expect_false(is_formula(~ x + y, has_lhs = TRUE))
+  expect_true(is_formula(~ x + y, has_lhs = FALSE))
+  # two-sided formula
+  expect_true(is_formula(y ~ x, has_lhs = NA))
+  expect_true(is_formula(y ~ x, has_lhs = NULL))
+  expect_true(is_formula(y ~ x, has_lhs = TRUE))
+  expect_false(is_formula(y ~ x, has_lhs = FALSE))
+})


### PR DESCRIPTION
Add an argument to is_formula to additionally check whether the formula is one- or two-sided.

It was a function or argument that I was expecting, but didn't find, since testing whether a formula is one-sided or two-sided is pretty common, and even though the test is easy, checking the length is rather unclear.  

I don't know if this belongs with *lazyeval* or as separate functions, but I thought I'd open up this pull request to see what you thought.