### PR TITLE
Add `purrr_continue()`

### DIFF
--- a/R/map2.R
+++ b/R/map2.R
@@ -79,7 +79,7 @@ map2_ <- function(.type,
     i = i,
     names = names,
     error_call = .purrr_error_call,
-    call_with_cleanup(map2_impl, environment(), .type, .progress, n, names, i)
+    call_with_cleanup(map2_impl, environment(), .type, .progress, n, names, i, the)
   )
 }
 

--- a/R/package-purrr.R
+++ b/R/package-purrr.R
@@ -7,3 +7,6 @@
 "_PACKAGE"
 
 the <- new_environment()
+the$last_map_results <- NULL
+the$last_map_index <- NULL
+the$last_map <- NULL

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -128,7 +128,7 @@ pmap_ <- function(.type,
     i = i,
     names = names,
     error_call = .purrr_error_call,
-    call_with_cleanup(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n)
+    call_with_cleanup(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n, the)
   )
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -13,9 +13,9 @@
 extern SEXP coerce_impl(SEXP, SEXP);
 extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP);
 extern SEXP flatten_impl(SEXP);
-extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP transpose_impl(SEXP, SEXP);
 extern SEXP vflatten_impl(SEXP, SEXP);
 
@@ -24,9 +24,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"coerce_impl",           (DL_FUNC) &coerce_impl,    2},
   {"pluck_impl",            (DL_FUNC) &pluck_impl,     4},
   {"flatten_impl",          (DL_FUNC) &flatten_impl,   1},
-  {"map_impl",              (DL_FUNC) &map_impl,       6},
-  {"map2_impl",             (DL_FUNC) &map2_impl,      6},
-  {"pmap_impl",             (DL_FUNC) &pmap_impl,      8},
+  {"map_impl",              (DL_FUNC) &map_impl,       7},
+  {"map2_impl",             (DL_FUNC) &map2_impl,      7},
+  {"pmap_impl",             (DL_FUNC) &pmap_impl,      9},
   {"transpose_impl",        (DL_FUNC) &transpose_impl, 2},
   {"vflatten_impl",         (DL_FUNC) &vflatten_impl,  2},
   {"purrr_eval",            (DL_FUNC) &Rf_eval,        2},


### PR DESCRIPTION
Closes #1099.

The idea is to easily continue a call to `map()` and keep intermediate results.

``` r
devtools::load_all("~/GitHub/purrr/")
#> ℹ Loading purrr

slow_function <- function(x) {
  if (x == 5) {
    stop("something went wrong")
  }
  
  x - 1
}

slow_function2 <- function(x) {
  print(x)
  x
}

to_process <- 1:10
map(1:10, slow_function)
#> [1] 0
#> Error in `map()`:
#> ℹ In index: 5.
#> Caused by error in `.f()`:
#> ! something went wrong
#> Backtrace:
#>      ▆
#>   1. ├─purrr::map(1:10, slow_function)
#>   2. │ └─purrr:::map_("list", .x, .f, ..., .progress = .progress) at purrr/R/map.R:129:2
#>   3. │   ├─purrr:::with_indexed_errors(...) at purrr/R/map.R:182:2
#>   4. │   │ └─base::withCallingHandlers(...) at purrr/R/map.R:234:2
#>   5. │   ├─purrr:::call_with_cleanup(...)
#>   6. │   └─global .f(.x[[i]], ...)
#>   7. │     └─base::stop("something went wrong")
#>   8. └─base::.handleSimpleError(...)
#>   9.   └─purrr (local) h(simpleError(msg, call))
#>  10.     └─cli::cli_abort(...) at purrr/R/map.R:248:8
#>  11.       └─rlang::abort(...)
all <- purrr_continue(.f = slow_function2)
#> [1] 5
#> [1] 6
#> [1] 7
#> [1] 8
#> [1] 9
#> [1] 10
all
#> [[1]]
#> [1] 0
#> 
#> [[2]]
#> [1] 1
#> 
#> [[3]]
#> [1] 2
#> 
#> [[4]]
#> [1] 3
#> 
#> [[5]]
#> [1] 5
#> 
#> [[6]]
#> [1] 6
#> 
#> [[7]]
#> [1] 7
#> 
#> [[8]]
#> [1] 8
#> 
#> [[9]]
#> [1] 9
#> 
#> [[10]]
#> [1] 10

# for some reason this now starts at 5 :-(
run2 <- map(1:10, slow_function)
#> [1] 5
```

<sup>Created on 2023-09-05 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>