### PR TITLE
Add "Supported By Posit" badge to website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,6 +6,7 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="purrr.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
@@ -96,9 +97,9 @@ reference:
 
 - title: Superseded
   description: |
-     Superseded functions have been replaced by superior solutions, but
-     due to their widespread use will not go away. However, they will not
-     get any new features and will only receive critical bug fixes.
+    Superseded functions have been replaced by superior solutions, but
+    due to their widespread use will not go away. However, they will not
+    get any new features and will only receive critical bug fixes.
   contents:
   - flatten
   - map_df


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:
<img width="1200" height="300" alt="purrr-1200" src="https://github.com/user-attachments/assets/3ca5eab1-9c26-4410-8dd9-a16653a2fc77" />

At 992px browser width:
<img width="992" height="300" alt="purrr-992" src="https://github.com/user-attachments/assets/5eaf34f7-fe15-4ec7-b7a5-275ad9a26a10" />

At 991px browser width:
<img width="991" height="300" alt="purrr-991" src="https://github.com/user-attachments/assets/842dda29-997f-453d-9492-ae72d4a758ee" />



