### PR TITLE
Fix typo in roxygen docs

### DIFF
--- a/R/deprec-invoke.R
+++ b/R/deprec-invoke.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' These functions were superded in purrr 0.3.0 and deprecated in purrr 1.0.0.
+#' These functions were superseded in purrr 0.3.0 and deprecated in purrr 1.0.0.
 #'
 #' * `invoke()` is deprecated in favour of the simpler `exec()` function
 #'   reexported from rlang. `exec()` evaluates a function call built

--- a/man/invoke.Rd
+++ b/man/invoke.Rd
@@ -51,7 +51,7 @@ as \code{.f} the name of a function rather than its value, or as
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-These functions were superded in purrr 0.3.0 and deprecated in purrr 1.0.0.
+These functions were superseded in purrr 0.3.0 and deprecated in purrr 1.0.0.
 \itemize{
 \item \code{invoke()} is deprecated in favour of the simpler \code{exec()} function
 reexported from rlang. \code{exec()} evaluates a function call built


### PR DESCRIPTION
This PR fixes a small typo in the roxygen docs