### PR TITLE
Clear `dim` before calling `list_flatten()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* Tweaks for compatibility with upcoming vctrs 0.7.0.
+
 # purrr 1.2.0
 
 ## Breaking changes

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -59,7 +59,11 @@ array_branch <- function(array, margin = NULL) {
     }
     as.list(array)
   } else {
-    list_flatten(apply(array, margin, list))
+    out <- apply(array, margin, list)
+    if (!is.null(dim(out))) {
+      dim(out) <- NULL
+    }
+    list_flatten(out)
   }
 }
 


### PR DESCRIPTION
We plan to release vctrs on Jan 15, and purrr was an affected revdep.

In vctrs, `obj_is_list()` no longer reports `TRUE` for a _list array_.

This is because most vctrs functions such as `list_drop_empty()` and `list_combine()` / `list_unchop()` validate their input using `obj_is_list()`, but they aren't well defined on list arrays. In other words when we say "list" in vctrs we really do mean a vector list, not an array list, and `size` related invariants and C code depend on that definition.

This change has affected `array_branch()`, since _sometimes_ `apply()` would return a list array and _sometimes_ it would return a bare list. I think it returns a list array when you apply over >1 dimensions at once, based on looking at the tests.

I am clearing the `dim` only when it exists, because if you clear the `dim` on a bare list then it also drops its names, and we have some tests that ensure that we _keep_ names when only going over 1 dimension.