### PR TITLE
Implement `compose()` lazily

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* `compose()` now evaluates lazily, allowing composing with functions like `capture.output()` (#651).
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/R/adverb-compose.R
+++ b/R/adverb-compose.R
@@ -53,20 +53,13 @@ compose <- function(..., .dir = c("backward", "forward")) {
   }
 
   composed <- function() {
-    env <- env(caller_env(), `_fn` = first_fn)
-
-    first_call <- sys.call()
-    first_call[[1]] <- quote(`_fn`)
-    env$`_out` <- .Call(purrr_eval, first_call, env)
-
-    call <- quote(`_fn`(`_out`))
+    `_call` <- call2(first_fn, !!!call_args(sys.call()))
 
     for (fn in fns) {
-      env$`_fn` <- fn
-      env$`_out` <- .Call(purrr_eval, call, env)
+      `_call` <- call2(.fn = fn, `_call`)
     }
 
-    env$`_out`
+    eval_tidy(`_call`, env = caller_env())
   }
   formals(composed) <- formals(first_fn)
 

--- a/tests/testthat/test-adverb-compose.R
+++ b/tests/testthat/test-adverb-compose.R
@@ -147,3 +147,11 @@ test_that("compose() can take dots from multiple environments", {
     c("_baz", "_bar", "_foo", "_quux")
   )
 })
+
+test_that("compose() evaluates lazily (#651)", {
+  expect_silent(compose(capture.output, print)("purrr, meow"))
+  expect_identical(
+    compose(capture.output, print)("purrr, meow"),
+    capture.output(print("purrr, meow"))
+  )
+})


### PR DESCRIPTION
Fixes #651 🦔 

I simplified the code a bit by making the `composed()` function simply construct the `f3(f2(f1(...)))` call iteratively with `rlang::call2()` (my beloved) and only then evaluate it. Kind of wanted to use `reduce()` here, but there were interactions that made it not compose lazily, so an old `for` loop it is then.

Technically, it should be possible to move most of that call creation outside of `composed()` function for potential performance gains (i.e. have a predefined `f3(f2(f1()))` call in the outer env and only insert parameters and evaluate during the actual call), but I can't see an easy way to do it right now.

~As with #1246, the last commit contains updated snaps for vctrs v0.7.0.~