### PR TITLE
Add explicit parameters wherever necessary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # purrr (development version)
 
+* The following functions gain an explicit `.progress` parameter: `keep()`, `discard()`, `compact()`, `modify()`, `modify2()`, `imodify()` (#1249).
+
+* `imap_vec()` gains an explicit `.ptype` parameter to match `map2_vec()` (#1244).
+
+* Many internal parameters across several functions are now passed with names to avoid accidental overwrite by user passing the same parameter to `...` (#1248).
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/R/detect.R
+++ b/R/detect.R
@@ -56,7 +56,7 @@ detect <- function(
   .dir = c("forward", "backward"),
   .default = NULL
 ) {
-  .f <- as_predicate(.f, ..., .mapper = TRUE)
+  .f <- as_predicate(.fn = .f, ..., .mapper = TRUE)
   .dir <- arg_match0(.dir, c("forward", "backward"))
 
   for (i in index(.x, .dir, "detect")) {
@@ -71,7 +71,7 @@ detect <- function(
 #' @export
 #' @rdname detect
 detect_index <- function(.x, .f, ..., .dir = c("forward", "backward")) {
-  .f <- as_predicate(.f, ..., .mapper = TRUE)
+  .f <- as_predicate(.fn = .f, ..., .mapper = TRUE)
   .dir <- arg_match0(.dir, c("forward", "backward"))
 
   for (i in index(.x, .dir, "detect_index")) {

--- a/R/every-some-none.R
+++ b/R/every-some-none.R
@@ -48,7 +48,7 @@ satisfies_predicate <- function(
   # Not using `as_predicate()` as R level predicate result checks are too slow.
   # Checks are done at the C level instead (#1169). Also, `NA` propagates
   # through these functions, which `as_predicate()` doesn't allow.
-  .p <- as_mapper(.p, ...)
+  .p <- as_mapper(.f = .p, ...)
 
   # Consistent with `map()`
   .x <- vctrs_vec_compat(.x, .purrr_user_env)

--- a/R/head-tail.R
+++ b/R/head-tail.R
@@ -14,8 +14,8 @@
 #' tail_while(0:10, big)
 head_while <- function(.x, .p, ...) {
   # Find location of first FALSE
-  .p <- as_predicate(.p, ..., .mapper = TRUE)
-  loc <- detect_index(.x, negate(.p), ...)
+  .p <- as_predicate(.fn = .p, ..., .mapper = TRUE)
+  loc <- detect_index(.x, .f = negate(.p), ..., .dir = "forward")
   if (loc == 0) {
     return(.x)
   }
@@ -26,9 +26,9 @@ head_while <- function(.x, .p, ...) {
 #' @export
 #' @rdname head_while
 tail_while <- function(.x, .p, ...) {
-  .p <- as_predicate(.p, ..., .mapper = TRUE)
+  .p <- as_predicate(.fn = .p, ..., .mapper = TRUE)
   # Find location of last FALSE
-  loc <- detect_index(.x, negate(.p), ..., .dir = "backward")
+  loc <- detect_index(.x, .f = negate(.p), ..., .dir = "backward")
   if (loc == 0) {
     return(.x)
   }

--- a/R/imap.R
+++ b/R/imap.R
@@ -63,9 +63,9 @@ imap_dbl <- function(.x, .f, ...) {
 
 #' @rdname imap
 #' @export
-imap_vec <- function(.x, .f, ...) {
+imap_vec <- function(.x, .f, ..., .ptype = NULL) {
   .f <- as_mapper(.f, ...)
-  map2_vec(.x, .y = vec_index(.x), .f, ...)
+  map2_vec(.x, .y = vec_index(.x), .f, ..., .ptype = .ptype)
 }
 
 

--- a/R/imap.R
+++ b/R/imap.R
@@ -30,42 +30,42 @@
 #' iwalk(mtcars, \(x, idx) cat(idx, ": ", median(x), "\n", sep = ""))
 imap <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
-  map2(.x, vec_index(.x), .f, ...)
+  map2(.x, .y = vec_index(.x), .f, ...)
 }
 
 #' @rdname imap
 #' @export
 imap_lgl <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
-  map2_lgl(.x, vec_index(.x), .f, ...)
+  map2_lgl(.x, .y = vec_index(.x), .f, ...)
 }
 
 #' @rdname imap
 #' @export
 imap_chr <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
-  map2_chr(.x, vec_index(.x), .f, ...)
+  map2_chr(.x, .y = vec_index(.x), .f, ...)
 }
 
 #' @rdname imap
 #' @export
 imap_int <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
-  map2_int(.x, vec_index(.x), .f, ...)
+  map2_int(.x, .y = vec_index(.x), .f, ...)
 }
 
 #' @rdname imap
 #' @export
 imap_dbl <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
-  map2_dbl(.x, vec_index(.x), .f, ...)
+  map2_dbl(.x, .y = vec_index(.x), .f, ...)
 }
 
 #' @rdname imap
 #' @export
 imap_vec <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
-  map2_vec(.x, vec_index(.x), .f, ...)
+  map2_vec(.x, .y = vec_index(.x), .f, ...)
 }
 
 
@@ -73,7 +73,7 @@ imap_vec <- function(.x, .f, ...) {
 #' @rdname imap
 iwalk <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
-  walk2(.x, vec_index(.x), .f, ...)
+  walk2(.x, .y = vec_index(.x), .f, ...)
 }
 
 

--- a/R/keep.R
+++ b/R/keep.R
@@ -20,6 +20,9 @@
 #'
 #' @seealso [keep_at()]/[discard_at()] to keep/discard elements by name.
 #' @param ... Additional arguments passed on to `.p`.
+#' @param .progress Whether to show a progress bar. Use `TRUE` to turn on
+#'   a basic progress bar, use a string to give it a name, or see
+#'   [progress_bars] for more details.
 #' @export
 #' @examples
 #' rep(10, 10) |>
@@ -41,23 +44,23 @@
 #' # compact() discards elements that are NULL or that have length zero
 #' list(a = "a", b = NULL, c = integer(0), d = NA, e = list()) |>
 #'   compact()
-keep <- function(.x, .p, ...) {
-  where <- where_if(.x, .p, ...)
+keep <- function(.x, .p, ..., .progress = FALSE) {
+  where <- where_if(.x, .p, ..., .progress = .progress)
   .x[!is.na(where) & where]
 }
 
 #' @export
 #' @rdname keep
-discard <- function(.x, .p, ...) {
-  where <- where_if(.x, .p, ...)
+discard <- function(.x, .p, ..., .progress = FALSE) {
+  where <- where_if(.x, .p, ..., .progress = .progress)
   .x[is.na(where) | !where]
 }
 
 #' @export
 #' @rdname keep
-compact <- function(.x, .p = identity) {
+compact <- function(.x, .p = identity, .progress = FALSE) {
   .f <- as_mapper(.p)
-  discard(.x, function(x) is_empty(.f(x)))
+  discard(.x, function(x) is_empty(.f(x)), .progress = .progress)
 }
 
 

--- a/R/lmap.R
+++ b/R/lmap.R
@@ -44,21 +44,21 @@
 #' # Or only where a condition is satisfied
 #' x |> lmap_if(is.character, maybe_rep) |> str()
 lmap <- function(.x, .f, ...) {
-  lmap_helper(.x, rep(TRUE, length(.x)), .f, ...)
+  lmap_helper(.x, .ind = rep(TRUE, length(.x)), .f, ..., .else = NULL)
 }
 
 #' @rdname lmap
 #' @export
 lmap_if <- function(.x, .p, .f, ..., .else = NULL) {
   where <- where_if(.x, .p)
-  lmap_helper(.x, where, .f, ..., .else = .else)
+  lmap_helper(.x, .ind = where, .f, ..., .else = .else)
 }
 
 #' @rdname lmap
 #' @export
 lmap_at <- function(.x, .at, .f, ...) {
   where <- where_at(.x, .at, user_env = caller_env())
-  lmap_helper(.x, where, .f, ...)
+  lmap_helper(.x, .ind = where, .f, ..., .else = NULL)
 }
 
 lmap_helper <- function(

--- a/R/map-depth.R
+++ b/R/map-depth.R
@@ -81,7 +81,7 @@ map_depth <- function(
   .f <- as_mapper(.f, ...)
   .is_node <- as_is_node(.is_node)
   map_depth_rec(
-    map,
+    .fmap = map,
     .x,
     .depth,
     .f,
@@ -106,7 +106,7 @@ modify_depth <- function(
   .f <- as_mapper(.f, ...)
   .is_node <- as_is_node(.is_node)
   map_depth_rec(
-    modify,
+    .fmap = modify,
     .x,
     .depth,
     .f,

--- a/R/map.R
+++ b/R/map.R
@@ -162,31 +162,31 @@
 #' mirai::daemons(0)
 #'
 map <- function(.x, .f, ..., .progress = FALSE) {
-  map_("list", .x, .f, ..., .progress = .progress)
+  map_(.type = "list", .x, .f, ..., .progress = .progress)
 }
 
 #' @rdname map
 #' @export
 map_lgl <- function(.x, .f, ..., .progress = FALSE) {
-  map_("logical", .x, .f, ..., .progress = .progress)
+  map_(.type = "logical", .x, .f, ..., .progress = .progress)
 }
 
 #' @rdname map
 #' @export
 map_int <- function(.x, .f, ..., .progress = FALSE) {
-  map_("integer", .x, .f, ..., .progress = .progress)
+  map_(.type = "integer", .x, .f, ..., .progress = .progress)
 }
 
 #' @rdname map
 #' @export
 map_dbl <- function(.x, .f, ..., .progress = FALSE) {
-  map_("double", .x, .f, ..., .progress = .progress)
+  map_(.type = "double", .x, .f, ..., .progress = .progress)
 }
 
 #' @rdname map
 #' @export
 map_chr <- function(.x, .f, ..., .progress = FALSE) {
-  map_("character", .x, .f, ..., .progress = .progress)
+  map_(.type = "character", .x, .f, ..., .progress = .progress)
 }
 
 map_ <- function(

--- a/R/map2.R
+++ b/R/map2.R
@@ -36,27 +36,27 @@
 #' mods <- by_cyl |> map(\(df) lm(mpg ~ wt, data = df))
 #' map2(mods, by_cyl, predict)
 map2 <- function(.x, .y, .f, ..., .progress = FALSE) {
-  map2_("list", .x, .y, .f, ..., .progress = .progress)
+  map2_(.type = "list", .x, .y, .f, ..., .progress = .progress)
 }
 #' @export
 #' @rdname map2
 map2_lgl <- function(.x, .y, .f, ..., .progress = FALSE) {
-  map2_("logical", .x, .y, .f, ..., .progress = .progress)
+  map2_(.type = "logical", .x, .y, .f, ..., .progress = .progress)
 }
 #' @export
 #' @rdname map2
 map2_int <- function(.x, .y, .f, ..., .progress = FALSE) {
-  map2_("integer", .x, .y, .f, ..., .progress = .progress)
+  map2_(.type = "integer", .x, .y, .f, ..., .progress = .progress)
 }
 #' @export
 #' @rdname map2
 map2_dbl <- function(.x, .y, .f, ..., .progress = FALSE) {
-  map2_("double", .x, .y, .f, ..., .progress = .progress)
+  map2_(.type = "double", .x, .y, .f, ..., .progress = .progress)
 }
 #' @export
 #' @rdname map2
 map2_chr <- function(.x, .y, .f, ..., .progress = FALSE) {
-  map2_("character", .x, .y, .f, ..., .progress = .progress)
+  map2_(.type = "character", .x, .y, .f, ..., .progress = .progress)
 }
 
 map2_ <- function(

--- a/R/modify.R
+++ b/R/modify.R
@@ -114,11 +114,11 @@ modify <- function(.x, .f, ...) {
 #' @export
 modify_if <- function(.x, .p, .f, ..., .else = NULL) {
   where <- where_if(.x, .p)
-  .x <- modify_where(.x, where, .f, ...)
+  .x <- modify_where(.x, .where = where, .f, ...)
 
   if (!is.null(.else)) {
     .else <- as_mapper(.else, ...)
-    .x <- modify_where(.x, !where, .else, ...)
+    .x <- modify_where(.x, .where = !where, .else, ...)
   }
 
   .x
@@ -166,7 +166,7 @@ modify2 <- function(.x, .y, .f, ...) {
 #' @rdname modify
 #' @export
 imodify <- function(.x, .f, ...) {
-  modify2(.x, vec_index(.x), .f, ...)
+  modify2(.x, .y = vec_index(.x), .f, ...)
 }
 
 # helpers -----------------------------------------------------------------

--- a/R/modify.R
+++ b/R/modify.R
@@ -129,7 +129,7 @@ modify_if <- function(.x, .p, .f, ..., .else = NULL) {
 #' @export
 modify_at <- function(.x, .at, .f, ...) {
   where <- where_at(.x, .at, user_env = caller_env())
-  modify_where(.x, where, .f, ...)
+  modify_where(.x, .where = where, .f, ...)
 }
 
 #' @rdname modify

--- a/R/modify.R
+++ b/R/modify.R
@@ -84,23 +84,23 @@
 #' # Specify an alternative with the `.else` argument:
 #' modify_if(iris, is.factor, as.character, .else = as.integer)
 #' @export
-modify <- function(.x, .f, ...) {
+modify <- function(.x, .f, ..., .progress = FALSE) {
   .f <- as_mapper(.f, ...)
 
   if (obj_is_list(.x)) {
-    out <- map(vec_proxy(.x), .f, ...)
+    out <- map(vec_proxy(.x), .f, ..., .progress = .progress)
     vec_restore(out, .x)
   } else if (is.data.frame(.x)) {
     size <- vec_size(.x)
     out <- unclass(vec_proxy(.x))
-    out <- map(out, .f, ...)
+    out <- map(out, .f, ..., .progress = .progress)
     out <- vec_recycle_common(!!!out, .size = size, .arg = "out")
     out <- new_data_frame(out, n = size)
     vec_restore(out, .x)
   } else if (vec_is(.x)) {
-    map_vec(.x, .f, ..., .ptype = .x)
+    map_vec(.x, .f, ..., .ptype = .x, .progress = .progress)
   } else if (is.list(.x) || is.null(.x)) {
-    .x[] <- map(.x, .f, ...)
+    .x[] <- map(.x, .f, ..., .progress = .progress)
     .x
   } else {
     cli::cli_abort(
@@ -134,23 +134,23 @@ modify_at <- function(.x, .at, .f, ...) {
 
 #' @rdname modify
 #' @export
-modify2 <- function(.x, .y, .f, ...) {
+modify2 <- function(.x, .y, .f, ..., .progress = FALSE) {
   .f <- as_mapper(.f, ...)
 
   if (obj_is_list(.x)) {
-    out <- map2(vec_proxy(.x), .y, .f, ...)
+    out <- map2(vec_proxy(.x), .y, .f, ..., .progress = .progress)
     vec_restore(out, .x)
   } else if (is.data.frame(.x)) {
     size <- vec_size(.x)
     out <- unclass(vec_proxy(.x))
-    out <- map2(out, .y, .f, ...)
+    out <- map2(out, .y, .f, ..., .progress = .progress)
     out <- vec_recycle_common(!!!out, .size = size, .arg = "out")
     out <- new_data_frame(out, n = size)
     vec_restore(out, .x)
   } else if (vec_is(.x)) {
-    map2_vec(.x, .y, .f, ..., .ptype = .x)
+    map2_vec(.x, .y, .f, ..., .ptype = .x, .progress = .progress)
   } else if (is.null(.x) || is.list(.x)) {
-    out <- map2(.x, .y, .f, ...)
+    out <- map2(.x, .y, .f, ..., .progress = .progress)
     if (length(out) > length(.x)) {
       .x <- .x[rep(1L, length(out))]
     }
@@ -165,8 +165,8 @@ modify2 <- function(.x, .y, .f, ...) {
 
 #' @rdname modify
 #' @export
-imodify <- function(.x, .f, ...) {
-  modify2(.x, .y = vec_index(.x), .f, ...)
+imodify <- function(.x, .f, ..., .progress = FALSE) {
+  modify2(.x, .y = vec_index(.x), .f, ..., .progress = .progress)
 }
 
 # helpers -----------------------------------------------------------------

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -98,28 +98,28 @@
 #' map2_dbl(df$x, df$y, min)
 #' pmap_dbl(df, min)
 pmap <- function(.l, .f, ..., .progress = FALSE) {
-  pmap_("list", .l, .f, ..., .progress = .progress)
+  pmap_(.type = "list", .l, .f, ..., .progress = .progress)
 }
 
 #' @export
 #' @rdname pmap
 pmap_lgl <- function(.l, .f, ..., .progress = FALSE) {
-  pmap_("logical", .l, .f, ..., .progress = .progress)
+  pmap_(.type = "logical", .l, .f, ..., .progress = .progress)
 }
 #' @export
 #' @rdname pmap
 pmap_int <- function(.l, .f, ..., .progress = FALSE) {
-  pmap_("integer", .l, .f, ..., .progress = .progress)
+  pmap_(.type = "integer", .l, .f, ..., .progress = .progress)
 }
 #' @export
 #' @rdname pmap
 pmap_dbl <- function(.l, .f, ..., .progress = FALSE) {
-  pmap_("double", .l, .f, ..., .progress = .progress)
+  pmap_(.type = "double", .l, .f, ..., .progress = .progress)
 }
 #' @export
 #' @rdname pmap
 pmap_chr <- function(.l, .f, ..., .progress = FALSE) {
-  pmap_("character", .l, .f, ..., .progress = .progress)
+  pmap_(.type = "character", .l, .f, ..., .progress = .progress)
 }
 
 pmap_ <- function(

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,8 +51,8 @@ where_if <- function(.x, .p, ..., .purrr_error_call = caller_env()) {
     stopifnot(length(.p) == length(.x))
     .p
   } else {
-    .p <- as_predicate(.p, ..., .mapper = TRUE, .purrr_error_call = NULL)
-    map_(.x, .p, ..., .type = "logical", .purrr_error_call = .purrr_error_call)
+    .p <- as_predicate(.fn = .p, ..., .mapper = TRUE, .purrr_error_call = NULL)
+    map_(.x, .f = .p, ..., .type = "logical", .purrr_error_call = .purrr_error_call)
   }
 }
 
@@ -67,7 +67,7 @@ as_predicate <- function(
   force(.purrr_error_arg)
 
   if (.mapper) {
-    .fn <- as_mapper(.fn, ...)
+    .fn <- as_mapper(.f = .fn, ...)
   }
 
   function(...) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,13 +46,13 @@ where_at <- function(
   }
 }
 
-where_if <- function(.x, .p, ..., .purrr_error_call = caller_env()) {
+where_if <- function(.x, .p, ..., .progress = FALSE, .purrr_error_call = caller_env()) {
   if (is_logical(.p)) {
     stopifnot(length(.p) == length(.x))
     .p
   } else {
     .p <- as_predicate(.fn = .p, ..., .mapper = TRUE, .purrr_error_call = NULL)
-    map_(.x, .f = .p, ..., .type = "logical", .purrr_error_call = .purrr_error_call)
+    map_(.x, .f = .p, ..., .type = "logical", .progress = .progress, .purrr_error_call = .purrr_error_call)
   }
 }
 

--- a/man/imap.Rd
+++ b/man/imap.Rd
@@ -20,7 +20,7 @@ imap_int(.x, .f, ...)
 
 imap_dbl(.x, .f, ...)
 
-imap_vec(.x, .f, ...)
+imap_vec(.x, .f, ..., .ptype = NULL)
 
 iwalk(.x, .f, ...)
 }
@@ -55,6 +55,10 @@ x |> map(\\(x) f(x, 1, 2, collapse = ","))
 
 This makes it easier to understand which arguments belong to which
 function and will tend to yield better error messages.}
+
+\item{.ptype}{If \code{NULL}, the default, the output type is the common type
+of the elements of the result. Otherwise, supply a "prototype" giving
+the desired type of output.}
 }
 \value{
 A vector the same length as \code{.x}.

--- a/man/keep.Rd
+++ b/man/keep.Rd
@@ -6,11 +6,11 @@
 \alias{compact}
 \title{Keep/discard elements based on their values}
 \usage{
-keep(.x, .p, ...)
+keep(.x, .p, ..., .progress = FALSE)
 
-discard(.x, .p, ...)
+discard(.x, .p, ..., .progress = FALSE)
 
-compact(.x, .p = identity)
+compact(.x, .p = identity, .progress = FALSE)
 }
 \arguments{
 \item{.x}{A list or vector.}
@@ -25,6 +25,10 @@ No longer recommended.
 }}
 
 \item{...}{Additional arguments passed on to \code{.p}.}
+
+\item{.progress}{Whether to show a progress bar. Use \code{TRUE} to turn on
+a basic progress bar, use a string to give it a name, or see
+\link{progress_bars} for more details.}
 }
 \description{
 \code{keep()} selects all elements where \code{.p} evaluates to \code{TRUE};

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -8,15 +8,15 @@
 \alias{imodify}
 \title{Modify elements selectively}
 \usage{
-modify(.x, .f, ...)
+modify(.x, .f, ..., .progress = FALSE)
 
 modify_if(.x, .p, .f, ..., .else = NULL)
 
 modify_at(.x, .at, .f, ...)
 
-modify2(.x, .y, .f, ...)
+modify2(.x, .y, .f, ..., .progress = FALSE)
 
-imodify(.x, .f, ...)
+imodify(.x, .f, ..., .progress = FALSE)
 }
 \arguments{
 \item{.x}{A vector.}
@@ -37,6 +37,10 @@ x |> map(\\(x) f(x, 1, 2, collapse = ","))
 
 This makes it easier to understand which arguments belong to which
 function and will tend to yield better error messages.}
+
+\item{.progress}{Whether to show a progress bar. Use \code{TRUE} to turn on
+a basic progress bar, use a string to give it a name, or see
+\link{progress_bars} for more details.}
 
 \item{.p}{A single predicate function, a formula describing such a
 predicate function, or a logical vector of the same length as \code{.x}.

--- a/tests/testthat/_snaps/every-some-none.md
+++ b/tests/testthat/_snaps/every-some-none.md
@@ -124,3 +124,27 @@
       Use of calls and expressions in purrr functions was deprecated in purrr 1.0.0.
       i Please coerce explicitly with `as.list()`
 
+# .f parameter passed to every(), some(), and none() doesn't override .p parameter
+
+    Code
+      every(1:5, is.null, .f = function(...) TRUE)
+    Condition
+      Error in `as_mapper()`:
+      ! formal argument ".f" matched by multiple actual arguments
+
+---
+
+    Code
+      some(1:5, is.null, .f = function(...) TRUE)
+    Condition
+      Error in `as_mapper()`:
+      ! formal argument ".f" matched by multiple actual arguments
+
+---
+
+    Code
+      none(1:5, is.null, .f = function(...) FALSE)
+    Condition
+      Error in `as_mapper()`:
+      ! formal argument ".f" matched by multiple actual arguments
+

--- a/tests/testthat/_snaps/head-tail.md
+++ b/tests/testthat/_snaps/head-tail.md
@@ -14,3 +14,35 @@
       Error in `tail_while()`:
       ! `.p()` must return a single `TRUE` or `FALSE`, not a logical vector.
 
+# .f parameter passed to head_while()/tail_while() doesn't override .p parameter
+
+    Code
+      head_while(5:-5, .f = function(x, ...) x < 3)
+    Condition
+      Error in `as_mapper()`:
+      ! formal argument ".f" matched by multiple actual arguments
+
+---
+
+    Code
+      tail_while(5:-5, .f = function(x, ...) x > 3)
+    Condition
+      Error in `as_mapper()`:
+      ! formal argument ".f" matched by multiple actual arguments
+
+# passing .dir parameter to head_while()/tail_while() results in an error
+
+    Code
+      head_while(5:-5, function(x) x < 0, .dir = "backward")
+    Condition
+      Error in `detect_index()`:
+      ! formal argument ".dir" matched by multiple actual arguments
+
+---
+
+    Code
+      tail_while(5:-5, function(x) x > 0, .dir = "forward")
+    Condition
+      Error in `detect_index()`:
+      ! formal argument ".dir" matched by multiple actual arguments
+

--- a/tests/testthat/_snaps/imap.md
+++ b/tests/testthat/_snaps/imap.md
@@ -1,0 +1,8 @@
+# passing .y parameter to imap() results in an error
+
+    Code
+      imap(5:1, sum, .y = 5:1)
+    Condition
+      Error in `map2()`:
+      ! formal argument ".y" matched by multiple actual arguments
+

--- a/tests/testthat/_snaps/keep.md
+++ b/tests/testthat/_snaps/keep.md
@@ -15,3 +15,16 @@
       Caused by error:
       ! `.p()` must return a single `TRUE` or `FALSE`, not `NA`.
 
+# passing .f parameter to keep() and discard() results in an error
+
+    Code
+      keep(1:5, .f = function(x, ...) x > 3, .p = NULL)
+    Condition
+      Error in `as_mapper()`:
+      ! formal argument ".f" matched by multiple actual arguments
+    Code
+      discard(1:5, .f = function(x, ...) x > 3, .p = NULL)
+    Condition
+      Error in `as_mapper()`:
+      ! formal argument ".f" matched by multiple actual arguments
+

--- a/tests/testthat/_snaps/lmap.md
+++ b/tests/testthat/_snaps/lmap.md
@@ -10,9 +10,20 @@
     Condition
       Error in `lmap()`:
       ! Can't convert `.f`, an environment, to a function.
+
+# passing .ind parameter to lmap() results in an error
+
     Code
-      lmap(list(1), ~1, .else = environment())
+      lmap(1, .ind = FALSE)
     Condition
-      Error in `lmap()`:
-      ! Can't convert `.else`, an environment, to a function.
+      Error in `lmap_helper()`:
+      ! formal argument ".ind" matched by multiple actual arguments
+
+# passing .else parameter to lmap_at() results in an error
+
+    Code
+      lmap_at(x, "c", function(x) list(1), .else = function(x) list(NULL))
+    Condition
+      Error in `lmap_helper()`:
+      ! formal argument ".else" matched by multiple actual arguments
 

--- a/tests/testthat/_snaps/map.md
+++ b/tests/testthat/_snaps/map.md
@@ -58,6 +58,14 @@
       Caused by error in `fail_at_3()`:
       ! Error
 
+# passing .type parameter to map() results in an error (#1248)
+
+    Code
+      map_lgl(function(x, ...) x, .type = "character")
+    Condition
+      Error in `map_()`:
+      ! formal argument ".type" matched by multiple actual arguments
+
 # requires output be length 1 and have common type
 
     Code

--- a/tests/testthat/_snaps/map2.md
+++ b/tests/testthat/_snaps/map2.md
@@ -48,3 +48,11 @@
       Error in `map2()`:
       ! Can't recycle `.x` (size 2) to match `.y` (size 0).
 
+# passing .type parameter to map2() results in an error (#1248)
+
+    Code
+      map2_dbl(1:4, function(x, ...) x, .type = "character")
+    Condition
+      Error in `map2_()`:
+      ! formal argument ".type" matched by multiple actual arguments
+

--- a/tests/testthat/_snaps/pmap.md
+++ b/tests/testthat/_snaps/pmap.md
@@ -47,3 +47,11 @@
       Error in `pmap()`:
       ! Can't recycle `.l[[1]]` (size 2) to match `.l[[2]]` (size 0).
 
+# passing .type parameter to map() results in an error (#1248)
+
+    Code
+      pmap(function(x, ...) x, .type = "character")
+    Condition
+      Error in `pmap_()`:
+      ! formal argument ".type" matched by multiple actual arguments
+

--- a/tests/testthat/test-every-some-none.R
+++ b/tests/testthat/test-every-some-none.R
@@ -172,3 +172,9 @@ test_that("pairlists, expressions, and calls are deprecated but work", {
   expect_snapshot(x <- every(quote(f(a, b)), is.name))
   expect_true(out)
 })
+
+test_that(".f parameter passed to every(), some(), and none() doesn't override .p parameter", {
+  expect_snapshot(every(1:5, is.null, .f = \(...) TRUE), error = TRUE)
+  expect_snapshot(some(1:5, is.null, .f = \(...) TRUE), error = TRUE)
+  expect_snapshot(none(1:5, is.null, .f = \(...) FALSE), error = TRUE)
+})

--- a/tests/testthat/test-head-tail.R
+++ b/tests/testthat/test-head-tail.R
@@ -17,3 +17,13 @@ test_that("head_while and tail_while require predicate function", {
   expect_snapshot(head_while(1:3, ~NA), error = TRUE)
   expect_snapshot(tail_while(1:3, ~ c(TRUE, FALSE)), error = TRUE)
 })
+
+test_that(".f parameter passed to head_while()/tail_while() doesn't override .p parameter", {
+  expect_snapshot(head_while(5:-5, .f = function(x, ...) x < 3), error = TRUE)
+  expect_snapshot(tail_while(5:-5, .f = function(x, ...) x > 3), error = TRUE)
+})
+
+test_that("passing .dir parameter to head_while()/tail_while() results in an error", {
+  expect_snapshot(head_while(5:-5, function(x) x < 0, .dir = "backward"), error = TRUE)
+  expect_snapshot(tail_while(5:-5, function(x) x > 0, .dir = "forward"), error = TRUE)
+})

--- a/tests/testthat/test-imap.R
+++ b/tests/testthat/test-imap.R
@@ -19,3 +19,7 @@ test_that("atomic vector imap works", {
 test_that("iwalk returns invisibly", {
   expect_output(iwalk(mtcars, ~ cat(.y, ": ", median(.x), "\n", sep = "")))
 })
+
+test_that("passing .y parameter to imap() results in an error", {
+  expect_snapshot(imap(5:1, sum, .y = 5:1), error = TRUE)
+})

--- a/tests/testthat/test-keep.R
+++ b/tests/testthat/test-keep.R
@@ -15,6 +15,13 @@ test_that("keep() and discard() require predicate functions", {
   })
 })
 
+test_that("passing .f parameter to keep() and discard() results in an error", {
+  expect_snapshot(error = TRUE, {
+    keep(1:5, .f = function(x, ...) x > 3, .p = NULL)
+    discard(1:5, .f = function(x, ...) x > 3, .p = NULL)
+  })
+})
+
 # keep_at / discard_at ----------------------------------------------------
 
 test_that("can keep_at/discard_at with character vector", {

--- a/tests/testthat/test-lmap.R
+++ b/tests/testthat/test-lmap.R
@@ -54,6 +54,14 @@ test_that("validates inputs", {
   expect_snapshot(error = TRUE, {
     lmap(list(1), ~1)
     lmap(list(1), environment())
-    lmap(list(1), ~1, .else = environment())
   })
+})
+
+test_that("passing .ind parameter to lmap() results in an error", {
+  expect_snapshot(lmap(1, .ind = FALSE), error = TRUE)
+})
+
+test_that("passing .else parameter to lmap_at() results in an error", {
+  x <- list(a = 1, b = 2, c = 3, d = 4)
+  expect_snapshot(lmap_at(x, "c", \(x) list(1), .else = \(x) list(NULL)), error = TRUE)
 })

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -121,6 +121,9 @@ test_that("map() with empty input copies names", {
   expect_identical(map_chr(named_list, identity), named(chr()))
 })
 
+test_that("passing .type parameter to map() results in an error (#1248)", {
+  expect_snapshot(map_lgl(\(x, ...) x, .type = "character"), error = TRUE)
+})
 
 # map_vec -----------------------------------------------------------------
 

--- a/tests/testthat/test-map2.R
+++ b/tests/testthat/test-map2.R
@@ -73,3 +73,7 @@ test_that("don't evaluate symbolic objects (#428)", {
   map2(exprs(1 + 2), NA, ~ expect_identical(.x, quote(1 + 2)))
   walk2(exprs(1 + 2), NA, ~ expect_identical(.x, quote(1 + 2)))
 })
+
+test_that("passing .type parameter to map2() results in an error (#1248)", {
+  expect_snapshot(map2_dbl(1:4, \(x, ...) x, .type = "character"), error = TRUE)
+})

--- a/tests/testthat/test-pmap.R
+++ b/tests/testthat/test-pmap.R
@@ -113,3 +113,7 @@ test_that("don't evaluate symbolic objects (#428)", {
   pmap(list(exprs(1 + 2)), ~ expect_identical(.x, quote(1 + 2)))
   pwalk(list(exprs(1 + 2)), ~ expect_identical(.x, quote(1 + 2)))
 })
+
+test_that("passing .type parameter to map() results in an error (#1248)", {
+  expect_snapshot(pmap(\(x, ...) x, .type = "character"), error = TRUE)
+})


### PR DESCRIPTION
~~This is a draft, as I'm both waiting to see if I covered all possibilities and unsure if I'm not starting too many PRs at once.~~

Closes three small and related issues 🦔 

Closes #1244: `.ptype` is now explicitly stated for `imap_vec()`. Couldn't think of a test case.

Closes #1249: `.progress` is now explicitly stated for `keep()`, `discard()`, `modify()`, `modify2()`, and `imodify()`. Moreover, `compact()` gained one as well. I'm on the fence regarding `map_if()` and `modify_if()`, since these two functions may spawn two progress bars if `.else` is specified. I don't want to allow it like that, but also I don't want to forbid it, as some people may be using it. I might do a C rewrite one day that would handle it better than R code could.

Closes #1248: Many internal parameters are now passed named. These names were added whenever there were `...` upstream that could take that parameter and pass it down without it being consumed anywhere. Now, whenever the user passes, say, `.else` to `lmap_at()`, they will get an error stating that that formal argument was matched by more than one actual argument. While the error could be a bit more clear, it should be an upgrade over the current state where the user would usually get errors related to mismatching types of different arguments due to them oftentimes being pushed down by that user-added argument. Or, occassionally, not get an error at all. This one got a few test cases to cover some of the possible parameter names that a given function shouldn't allow in `...`.