### PR TITLE
Optimize `detect_index()` and derivatives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* `detect()`, `detect_index()`, `head_while()`, and `tail_while()` were rewritten in C, leading to significantly improved performance.
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/R/detect.R
+++ b/R/detect.R
@@ -56,7 +56,7 @@ detect <- function(
   .dir = c("forward", "backward"),
   .default = NULL
 ) {
-  index <- detect_index(.x, .f, ..., .dir = .dir)
+  index <- which_satisfies_predicate(.x, .f, ..., .dir = .dir)
   if (index == 0) .default else .x[[index]]
 }
 

--- a/R/detect.R
+++ b/R/detect.R
@@ -66,6 +66,18 @@ detect_index <- function(.x, .f, ..., .dir = c("forward", "backward")) {
   which_satisfies_predicate(.x, .p = .f, ..., .dir = .dir, .negate = FALSE, .p_arg_name = ".f")
 }
 
+#' Which element satisfies a predicate?
+#'
+#' @inheritParams detect_index
+#' @param .negate If `TRUE`, this function finds the first element that
+#'  _doesn't_ satisfy the predicate instead.
+#' @param .p_arg_name Name of the `.p` argument in the caller function.
+#'  Used to handle the fact that `detect()` and `detect_index()` use `.f`
+#'  instead of expected `p`.
+#'
+#' @return The position of the matching item; if no match, 0.
+#'
+#' @noRd
 which_satisfies_predicate <- function(
   .x,
   .p,

--- a/R/detect.R
+++ b/R/detect.R
@@ -56,14 +56,14 @@ detect <- function(
   .dir = c("forward", "backward"),
   .default = NULL
 ) {
-  index <- which_satisfies_predicate(.x, .f, ..., .dir = .dir)
+  index <- which_satisfies_predicate(.x, .f, ..., .dir = .dir, .negate = FALSE)
   if (index == 0) .default else .x[[index]]
 }
 
 #' @export
 #' @rdname detect
 detect_index <- function(.x, .f, ..., .dir = c("forward", "backward")) {
-  which_satisfies_predicate(.x, .f, ..., .dir = .dir)
+  which_satisfies_predicate(.x, .f, ..., .dir = .dir, .negate = FALSE)
 }
 
 which_satisfies_predicate <- function(
@@ -71,6 +71,7 @@ which_satisfies_predicate <- function(
   .f,
   ...,
   .dir = c("forward", "backward"),
+  .negate = FALSE,
   .purrr_user_env = caller_env(2),
   .purrr_error_call = caller_env()
 ) {
@@ -88,7 +89,7 @@ which_satisfies_predicate <- function(
   i <- 0L
 
   # We refer to `.p`, `.x`, `i`, `...`, and `.purrr_error_call` all from C level
-  .Call(detect_index_impl, environment(), n, i, left)
+  .Call(detect_index_impl, environment(), n, i, left, .negate)
 }
 
 #' Does a list contain an object?

--- a/R/detect.R
+++ b/R/detect.R
@@ -76,8 +76,7 @@ which_satisfies_predicate <- function(
 ) {
   left <- arg_match0(.dir, c("forward", "backward")) == "forward"
   # Not using `as_predicate()` as R level predicate result checks are too slow.
-  # Checks are done at the C level instead (#1169). Also, `NA` propagates
-  # through these functions, which `as_predicate()` doesn't allow.
+  # Checks are done at the C level instead (#1169).
   .p <- as_mapper(.f, ...)
 
   # Consistent with `map()`

--- a/R/detect.R
+++ b/R/detect.R
@@ -56,29 +56,30 @@ detect <- function(
   .dir = c("forward", "backward"),
   .default = NULL
 ) {
-  index <- which_satisfies_predicate(.x, .f, ..., .dir = .dir, .negate = FALSE)
+  index <- which_satisfies_predicate(.x, .p = .f, ..., .dir = .dir, .negate = FALSE, .p_arg_name = ".f")
   if (index == 0) .default else .x[[index]]
 }
 
 #' @export
 #' @rdname detect
 detect_index <- function(.x, .f, ..., .dir = c("forward", "backward")) {
-  which_satisfies_predicate(.x, .f, ..., .dir = .dir, .negate = FALSE)
+  which_satisfies_predicate(.x, .p = .f, ..., .dir = .dir, .negate = FALSE, .p_arg_name = ".f")
 }
 
 which_satisfies_predicate <- function(
   .x,
-  .f,
+  .p,
   ...,
   .dir = c("forward", "backward"),
   .negate = FALSE,
+  .p_arg_name = ".p",
   .purrr_user_env = caller_env(2),
   .purrr_error_call = caller_env()
 ) {
   left <- arg_match0(.dir, c("forward", "backward")) == "forward"
   # Not using `as_predicate()` as R level predicate result checks are too slow.
   # Checks are done at the C level instead (#1169).
-  .p <- as_mapper(.f, ...)
+  .p <- as_mapper(.p, ...)
 
   # Consistent with `map()`
   .x <- vctrs_vec_compat(.x, .purrr_user_env)
@@ -88,7 +89,7 @@ which_satisfies_predicate <- function(
 
   i <- 0L
 
-  # We refer to `.p`, `.x`, `i`, `...`, and `.purrr_error_call` all from C level
+  # We refer to `.p`, `.x`, `i`, `...`, `.p_arg_name`, and `.purrr_error_call` all from C level
   .Call(detect_index_impl, environment(), n, i, left, .negate)
 }
 

--- a/R/detect.R
+++ b/R/detect.R
@@ -56,40 +56,40 @@ detect <- function(
   .dir = c("forward", "backward"),
   .default = NULL
 ) {
-  .f <- as_predicate(.f, ..., .mapper = TRUE)
-  .dir <- arg_match0(.dir, c("forward", "backward"))
-
-  for (i in index(.x, .dir, "detect")) {
-    if (.f(.x[[i]], ...)) {
-      return(.x[[i]])
-    }
-  }
-
-  .default
+  index <- detect_index(.x, .f, ..., .dir = .dir)
+  if (index == 0) .default else .x[[index]]
 }
 
 #' @export
 #' @rdname detect
 detect_index <- function(.x, .f, ..., .dir = c("forward", "backward")) {
-  .f <- as_predicate(.f, ..., .mapper = TRUE)
-  .dir <- arg_match0(.dir, c("forward", "backward"))
-
-  for (i in index(.x, .dir, "detect_index")) {
-    if (.f(.x[[i]], ...)) {
-      return(i)
-    }
-  }
-
-  0L
+  which_satisfies_predicate(.x, .f, ..., .dir = .dir)
 }
 
+which_satisfies_predicate <- function(
+  .x,
+  .f,
+  ...,
+  .dir = c("forward", "backward"),
+  .purrr_user_env = caller_env(2),
+  .purrr_error_call = caller_env()
+) {
+  left <- arg_match0(.dir, c("forward", "backward")) == "forward"
+  # Not using `as_predicate()` as R level predicate result checks are too slow.
+  # Checks are done at the C level instead (#1169). Also, `NA` propagates
+  # through these functions, which `as_predicate()` doesn't allow.
+  .p <- as_mapper(.f, ...)
 
-index <- function(x, dir, right = NULL, fn) {
-  idx <- seq_along(x)
-  if (dir == "backward") {
-    idx <- rev(idx)
-  }
-  idx
+  # Consistent with `map()`
+  .x <- vctrs_vec_compat(.x, .purrr_user_env)
+  obj_check_vector(.x, arg = ".x", call = .purrr_error_call)
+
+  n <- vec_size(.x)
+
+  i <- 0L
+
+  # We refer to `.p`, `.x`, `i`, `...`, and `.purrr_error_call` all from C level
+  .Call(detect_index_impl, environment(), n, i, left)
 }
 
 #' Does a list contain an object?

--- a/R/head-tail.R
+++ b/R/head-tail.R
@@ -14,7 +14,7 @@
 #' tail_while(0:10, big)
 head_while <- function(.x, .p, ...) {
   # Find location of first FALSE
-  loc <- which_satisfies_predicate(.x, .f = .p, ..., .dir = "forward", .negate = TRUE)
+  loc <- which_satisfies_predicate(.x, .p, ..., .dir = "forward", .negate = TRUE, .p_arg_name = ".p")
   if (loc == 0) {
     return(.x)
   }
@@ -26,7 +26,7 @@ head_while <- function(.x, .p, ...) {
 #' @rdname head_while
 tail_while <- function(.x, .p, ...) {
   # Find location of last FALSE
-  loc <- which_satisfies_predicate(.x, .f = .p, ..., .dir = "backward", .negate = TRUE)
+  loc <- which_satisfies_predicate(.x, .p, ..., .dir = "backward", .negate = TRUE, .p_arg_name = ".p")
   if (loc == 0) {
     return(.x)
   }

--- a/R/head-tail.R
+++ b/R/head-tail.R
@@ -14,8 +14,7 @@
 #' tail_while(0:10, big)
 head_while <- function(.x, .p, ...) {
   # Find location of first FALSE
-  .p <- as_predicate(.p, ..., .mapper = TRUE)
-  loc <- detect_index(.x, negate(.p), ...)
+  loc <- which_satisfies_predicate(.x, .f = .p, ..., .dir = "forward", .negate = TRUE)
   if (loc == 0) {
     return(.x)
   }
@@ -26,9 +25,8 @@ head_while <- function(.x, .p, ...) {
 #' @export
 #' @rdname head_while
 tail_while <- function(.x, .p, ...) {
-  .p <- as_predicate(.p, ..., .mapper = TRUE)
   # Find location of last FALSE
-  loc <- detect_index(.x, negate(.p), ..., .dir = "backward")
+  loc <- which_satisfies_predicate(.x, .f = .p, ..., .dir = "backward", .negate = TRUE)
   if (loc == 0) {
     return(.x)
   }

--- a/src/detect.c
+++ b/src/detect.c
@@ -11,11 +11,19 @@ bool is_bool(SEXP x) {
 }
 
 /**
- * C loop for `every()`, `some()`, and `none()`
+ * C loop for `detect_index()`
  *
  * Uses `vctrs_vec_compat()` at the R level so that we can use `vec_size()` to
  * compute `n`, while also using `[[` to extract elements, which is consistent
  * with `map()`.
+ *
+ * Very similar to `satisfies_predicate()` used by `every()`, `some()`, and
+ * `none()`. The differences are:
+ * - this function returns an index of the element that satisfies the predicate,
+ *   while the other one returns a boolean;
+ * - this function doesn't allow NA, while the other one propagates it;
+ * - this function allows both "forward" and "backward" directions, while the
+ *   other one has only implicit "forward".
  */
 static
 int which_satisfies_predicate(SEXP env, SEXP ffi_n, SEXP ffi_i, SEXP left_arg) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -1,0 +1,84 @@
+#define R_NO_REMAP
+#include <R.h>
+#include <Rinternals.h>
+#include <stdbool.h>
+
+#include "conditions.h"
+
+static
+bool is_bool(SEXP x) {
+  return TYPEOF(x) == LGLSXP && Rf_xlength(x) == 1 && !R_IsNA(LOGICAL_ELT(x, 0));
+}
+
+/**
+ * C loop for `every()`, `some()`, and `none()`
+ *
+ * Uses `vctrs_vec_compat()` at the R level so that we can use `vec_size()` to
+ * compute `n`, while also using `[[` to extract elements, which is consistent
+ * with `map()`.
+ */
+static
+int which_satisfies_predicate(SEXP env, SEXP ffi_n, SEXP ffi_i, SEXP left_arg) {
+  const bool left = Rf_asLogical(left_arg);
+  const int n = INTEGER_ELT(ffi_n, 0);
+  int* p_i = INTEGER(ffi_i);
+
+  static SEXP call = NULL;
+  if (call == NULL) {
+    SEXP x_sym = Rf_install(".x");
+    SEXP p_sym = Rf_install(".p");
+    SEXP i_sym = Rf_install("i");
+
+    // Constructs a call of the form .p(.x[[i]], ...)
+    SEXP x_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, x_sym, i_sym));
+
+    call = Rf_lang3(p_sym, x_i_sym, R_DotsSymbol);
+    R_PreserveObject(call);
+
+    UNPROTECT(1);
+  }
+
+  int out = 0;
+
+  for (int i = 0; i < n; ++i) {
+    int r_index = left ? i + 1 : n - i;
+    *p_i = r_index;
+
+    if (i % 1024 == 0) {
+      R_CheckUserInterrupt();
+    }
+
+    SEXP elt_sexp = PROTECT(R_forceAndCall(call, 1, env));
+
+    if (!is_bool(elt_sexp)) {
+      // We don't pass `.purrr_error_call` through `.Call()` so we can avoid
+      // evaluating it when it isn't needed, so we have to retrieve it when
+      // required.
+      SEXP error_call = PROTECT(Rf_eval(Rf_install(".purrr_error_call"), env));
+
+      r_abort_call(
+        error_call,
+        "`.f()` must return a single `TRUE` or `FALSE`, not %s.",
+        rlang_obj_type_friendly_full(elt_sexp, true, false)
+      );
+    }
+
+    const int elt = LOGICAL_ELT(elt_sexp, 0);
+    UNPROTECT(1);
+
+    if (elt) {
+      // Early exit
+      out = r_index;
+      break;
+    }
+  }
+
+  *p_i = 0;
+
+  return out;
+}
+
+SEXP detect_index_impl(SEXP ffi_env, SEXP ffi_n, SEXP ffi_i, SEXP left_arg) {
+  const int which = which_satisfies_predicate(ffi_env, ffi_n, ffi_i, left_arg);
+  return Rf_ScalarInteger(which);
+}

--- a/src/detect.c
+++ b/src/detect.c
@@ -26,8 +26,15 @@ bool is_bool(SEXP x) {
  *   other one has only implicit "forward".
  */
 static
-int which_satisfies_predicate(SEXP env, SEXP ffi_n, SEXP ffi_i, SEXP left_arg) {
+int which_satisfies_predicate(
+  SEXP env,
+  SEXP ffi_n,
+  SEXP ffi_i,
+  SEXP left_arg,
+  SEXP negate_arg
+) {
   const bool left = Rf_asLogical(left_arg);
+  const bool negate = Rf_asLogical(negate_arg);
   const int n = INTEGER_ELT(ffi_n, 0);
   int* p_i = INTEGER(ffi_i);
 
@@ -74,7 +81,7 @@ int which_satisfies_predicate(SEXP env, SEXP ffi_n, SEXP ffi_i, SEXP left_arg) {
     const int elt = LOGICAL_ELT(elt_sexp, 0);
     UNPROTECT(1);
 
-    if (elt) {
+    if (elt != negate) {
       // Early exit
       out = r_index;
       break;
@@ -86,7 +93,15 @@ int which_satisfies_predicate(SEXP env, SEXP ffi_n, SEXP ffi_i, SEXP left_arg) {
   return out;
 }
 
-SEXP detect_index_impl(SEXP ffi_env, SEXP ffi_n, SEXP ffi_i, SEXP left_arg) {
-  const int which = which_satisfies_predicate(ffi_env, ffi_n, ffi_i, left_arg);
+SEXP detect_index_impl(
+  SEXP ffi_env,
+  SEXP ffi_n,
+  SEXP ffi_i,
+  SEXP left_arg,
+  SEXP negate_arg
+) {
+  const int which = which_satisfies_predicate(
+    ffi_env, ffi_n, ffi_i, left_arg, negate_arg
+  );
   return Rf_ScalarInteger(which);
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -70,10 +70,12 @@ int which_satisfies_predicate(
       // evaluating it when it isn't needed, so we have to retrieve it when
       // required.
       SEXP error_call = PROTECT(Rf_eval(Rf_install(".purrr_error_call"), env));
+      SEXP p_arg_name = PROTECT(Rf_eval(Rf_install(".p_arg_name"), env));
 
       r_abort_call(
         error_call,
-        "`.f()` must return a single `TRUE` or `FALSE`, not %s.",
+        "`%s()` must return a single `TRUE` or `FALSE`, not %s.",
+        CHAR(STRING_ELT(p_arg_name, 0)),
         rlang_obj_type_friendly_full(elt_sexp, true, false)
       );
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -7,7 +7,7 @@
 
 static
 bool is_bool(SEXP x) {
-  return TYPEOF(x) == LGLSXP && Rf_xlength(x) == 1 && !R_IsNA(LOGICAL_ELT(x, 0));
+  return TYPEOF(x) == LGLSXP && Rf_xlength(x) == 1 && LOGICAL_ELT(x, 0) != NA_LOGICAL;
 }
 
 /**

--- a/src/init.c
+++ b/src/init.c
@@ -18,6 +18,7 @@ extern SEXP flatten_impl(SEXP);
 extern SEXP every_impl(SEXP, SEXP, SEXP);
 extern SEXP some_impl(SEXP, SEXP, SEXP);
 extern SEXP none_impl(SEXP, SEXP, SEXP);
+extern SEXP detect_index_impl(SEXP, SEXP, SEXP, SEXP);
 extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -32,6 +33,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"every_impl",            (DL_FUNC) &every_impl,     3},
   {"some_impl",             (DL_FUNC) &some_impl,      3},
   {"none_impl",             (DL_FUNC) &none_impl,      3},
+  {"detect_index_impl",     (DL_FUNC) &detect_index_impl, 4},
   {"map_impl",              (DL_FUNC) &map_impl,       6},
   {"map2_impl",             (DL_FUNC) &map2_impl,      6},
   {"pmap_impl",             (DL_FUNC) &pmap_impl,      8},

--- a/src/init.c
+++ b/src/init.c
@@ -18,7 +18,7 @@ extern SEXP flatten_impl(SEXP);
 extern SEXP every_impl(SEXP, SEXP, SEXP);
 extern SEXP some_impl(SEXP, SEXP, SEXP);
 extern SEXP none_impl(SEXP, SEXP, SEXP);
-extern SEXP detect_index_impl(SEXP, SEXP, SEXP, SEXP);
+extern SEXP detect_index_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -33,7 +33,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"every_impl",            (DL_FUNC) &every_impl,     3},
   {"some_impl",             (DL_FUNC) &some_impl,      3},
   {"none_impl",             (DL_FUNC) &none_impl,      3},
-  {"detect_index_impl",     (DL_FUNC) &detect_index_impl, 4},
+  {"detect_index_impl",     (DL_FUNC) &detect_index_impl, 5},
   {"map_impl",              (DL_FUNC) &map_impl,       6},
   {"map2_impl",             (DL_FUNC) &map2_impl,      6},
   {"pmap_impl",             (DL_FUNC) &pmap_impl,      8},

--- a/tests/testthat/_snaps/detect.md
+++ b/tests/testthat/_snaps/detect.md
@@ -1,7 +1,39 @@
-# `detect()` requires a predicate function
+# detect() and detect_index() require boolean results
 
     Code
-      detect(list(1:2, 2), is.na)
+      detect(list(1), function(x) 1)
+    Condition
+      Error in `detect()`:
+      ! `.f()` must return a single `TRUE` or `FALSE`, not the number 1.
+
+---
+
+    Code
+      detect_index(list(1), function(x) 1)
+    Condition
+      Error in `detect_index()`:
+      ! `.f()` must return a single `TRUE` or `FALSE`, not the number 1.
+
+---
+
+    Code
+      detect(list(1), function(x) NA)
+    Condition
+      Error in `detect()`:
+      ! `.f()` must return a single `TRUE` or `FALSE`, not `NA`.
+
+---
+
+    Code
+      detect_index(list(1), function(x) NA)
+    Condition
+      Error in `detect_index()`:
+      ! `.f()` must return a single `TRUE` or `FALSE`, not `NA`.
+
+---
+
+    Code
+      detect(list(1), function(x) c(TRUE, FALSE))
     Condition
       Error in `detect()`:
       ! `.f()` must return a single `TRUE` or `FALSE`, not a logical vector.
@@ -9,8 +41,26 @@
 ---
 
     Code
-      detect_index(list(1:2, 2), is.na)
+      detect_index(list(1), function(x) c(TRUE, FALSE))
     Condition
       Error in `detect_index()`:
       ! `.f()` must return a single `TRUE` or `FALSE`, not a logical vector.
+
+# detect() and detect_index() require vector `.x`
+
+    Code
+      detect(function() 1, identity)
+    Condition
+      Error in `detect()`:
+      ! `.x` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
+
+---
+
+    Code
+      detect_index(function() 1, identity)
+    Condition
+      Error in `detect_index()`:
+      ! `.x` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 

--- a/tests/testthat/_snaps/head-tail.md
+++ b/tests/testthat/_snaps/head-tail.md
@@ -1,7 +1,23 @@
-# head_while and tail_while require predicate function
+# head_while() and tail_while() require boolean results
 
     Code
-      head_while(1:3, ~NA)
+      head_while(list(1), function(x) 1)
+    Condition
+      Error in `head_while()`:
+      ! `.p()` must return a single `TRUE` or `FALSE`, not the number 1.
+
+---
+
+    Code
+      tail_while(list(1), function(x) 1)
+    Condition
+      Error in `tail_while()`:
+      ! `.p()` must return a single `TRUE` or `FALSE`, not the number 1.
+
+---
+
+    Code
+      head_while(list(1), function(x) NA)
     Condition
       Error in `head_while()`:
       ! `.p()` must return a single `TRUE` or `FALSE`, not `NA`.
@@ -9,8 +25,42 @@
 ---
 
     Code
-      tail_while(1:3, ~ c(TRUE, FALSE))
+      tail_while(list(1), function(x) NA)
+    Condition
+      Error in `tail_while()`:
+      ! `.p()` must return a single `TRUE` or `FALSE`, not `NA`.
+
+---
+
+    Code
+      head_while(list(1), function(x) c(TRUE, FALSE))
+    Condition
+      Error in `head_while()`:
+      ! `.p()` must return a single `TRUE` or `FALSE`, not a logical vector.
+
+---
+
+    Code
+      tail_while(list(1), function(x) c(TRUE, FALSE))
     Condition
       Error in `tail_while()`:
       ! `.p()` must return a single `TRUE` or `FALSE`, not a logical vector.
+
+# head_while() and tail_while() require vector `.x`
+
+    Code
+      head_while(function() 1, identity)
+    Condition
+      Error in `head_while()`:
+      ! `.x` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
+
+---
+
+    Code
+      tail_while(function() 1, identity)
+    Condition
+      Error in `tail_while()`:
+      ! `.x` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 

--- a/tests/testthat/test-detect.R
+++ b/tests/testthat/test-detect.R
@@ -1,27 +1,167 @@
 y <- 4:10
+is_odd <- function(x) x %% 2 == 1
 
-test_that("detect functions work", {
-  is_odd <- function(x) x %% 2 == 1
-  expect_equal(detect(y, is_odd), 5)
-  expect_equal(detect_index(y, is_odd), 2)
-  expect_equal(detect(y, is_odd, .dir = "backward"), 9)
-  expect_equal(detect_index(y, is_odd, .dir = "backward"), 6)
+# detect() ---------------------------------------------------------------------
+
+## Basic functionality ----
+test_that("detect() works correctly in the basic case", {
+  expect_identical(detect(y, is_odd), 5L)
 })
 
-test_that("detect returns NULL when match not found", {
+test_that("detect() returns NULL when match not found", {
   expect_null(detect(y, function(x) x > 11))
 })
 
-test_that("detect_index returns 0 when match not found", {
-  expect_equal(detect_index(y, function(x) x > 11), 0)
+## .dir tests ----
+test_that("direction of detect() determines which value is detected first", {
+  expect_identical(detect(y, is_odd, .dir = "backward"), 9L)
 })
 
-test_that("has_element checks whether a list contains an object", {
+## .default tests ----
+test_that("detect() returns `.default` when specified and match not found", {
+  default <- list(value = NULL, error = "encountered")
+
+  expect_identical(detect(y, is_odd, .default = default), 5L)
+  expect_identical(
+    detect(y, function(x) x > 11, .default = default),
+    default
+  )
+})
+
+# detect_index() ---------------------------------------------------------------
+
+## Basic functionality ----
+test_that("detect functions work", {
+  expect_identical(detect_index(y, is_odd), 2L)
+})
+
+test_that("detect_index() returns 0 when match not found", {
+  expect_identical(detect_index(y, function(x) x > 11), 0L)
+})
+
+## .dir tests ----
+test_that("direction of detect_index() determines which value is detected first", {
+  expect_identical(detect_index(y, is_odd, .dir = "backward"), 6L)
+})
+
+test_that("index found when looking backward cannot be lower than when looking forward", {
+  integers <- sample.int(1e6, 20)
+  is_small <- function(x) x < 5e4
+
+  expect_gte(
+    detect_index(integers, is_small, .dir = "backward"),
+    detect_index(integers, is_small)
+  )
+})
+
+# Shared tests -----------------------------------------------------------------
+
+## Empty size behavior ----
+test_that("detect() and detect_index() have correct empty size behavior", {
+  # No elements to detect in
+  expect_identical(detect(list(), identity, .default = -1L), -1L)
+  expect_identical(detect_index(list(), identity), 0L)
+})
+
+test_that("detect() and detect_index() work on `NULL`", {
+  # No elements to detect in
+  expect_identical(detect(NULL, identity, .default = -1L), -1L)
+  expect_identical(detect_index(NULL, identity), 0L)
+})
+
+## .f requirements ----
+test_that("detect() and detect_index() require boolean results", {
+  # No coercion to `TRUE` or `FALSE`
+  expect_snapshot(detect(list(1), function(x) 1), error = TRUE)
+  expect_snapshot(detect_index(list(1), function(x) 1), error = TRUE)
+
+  # `NA` is not allowed whatsoever
+  expect_snapshot(detect(list(1), function(x) NA), error = TRUE)
+  expect_snapshot(detect_index(list(1), function(x) NA), error = TRUE)
+
+  # Must be length 1
+  expect_snapshot(detect(list(1), function(x) c(TRUE, FALSE)), error = TRUE)
+  expect_snapshot(detect_index(list(1), function(x) c(TRUE, FALSE)), error = TRUE)
+
+  # Attributes are allowed, we ignore them
+  expect_equal(detect(list(1), function(x) structure(TRUE, foo = "bar")), 1)
+  expect_equal(detect_index(list(1), function(x) structure(TRUE, foo = "bar")), 1L)
+
+  # Classes are allowed for historical reasons.
+  # We probably wouldn't consider these to be logical scalars these days.
+  expect_equal(detect(list(1), function(x) structure(TRUE, class = "mylgl")), 1)
+  expect_equal(detect_index(list(1), function(x) structure(TRUE, class = "mylgl")), 1L)
+
+  # We bypass any S3 `length()` methods!
+  local_methods(length.mylgl = function(x) 2L)
+  expect_equal(detect(list(1), function(x) structure(TRUE, class = "mylgl")), 1)
+  expect_equal(detect_index(list(1), function(x) structure(TRUE, class = "mylgl")), 1L)
+})
+
+## .x requirements ----
+test_that("detect() and detect_index() require vector `.x`", {
+  expect_snapshot(detect(function() 1, identity), error = TRUE)
+  expect_snapshot(detect_index(function() 1, identity), error = TRUE)
+})
+
+test_that("detect() and detect_index() work colwise across data frames", {
+  # If it naively worked off `vec_size()` then extracted elements with `[[`,
+  # this would return incorrect results. This definition is consistent with
+  # `map()`.
+  df <- data_frame(a = 1L, b = 2)
+  expect_identical(detect(df, is.integer), 1L)
+  expect_identical(detect_index(df, is.double), 2L)
+})
+
+test_that("detect() and detect_index() work on list scalars", {
+  # For consistency with `map()`
+  obj <- structure(list(1, "x"), class = "my_scalar")
+  expect_identical(detect(obj, is.double), 1)
+  expect_identical(detect_index(obj, is.character), 2L)
+})
+
+test_that("detect() and detect_index() work with vctrs records", {
+  x <- new_rcrd(list(x = c(1, 2, 3), y = c("a", "b", "c")))
+
+  out <- list()
+  detect(x, function(elt) {
+    out <<- append(out, list(elt))
+    FALSE
+  })
+  expect_identical(out, vec_chop(x))
+
+  out <- list()
+  detect_index(x, function(elt) {
+    out <<- append(out, list(elt))
+    FALSE
+  })
+  expect_identical(out, vec_chop(x))
+})
+
+## ... tests ----
+test_that("detect() and detect_index() pass ... to function", {
+  exceeds <- function(e1, e2) e1 > e2
+
+  expect_identical(
+    detect(y, exceeds, e2 = 8),
+    detect(y, function(x) { exceeds(x, e2 = 8) })
+  )
+  expect_identical(
+    detect_index(y, exceeds, e2 = 8),
+    detect_index(y, function(x) { exceeds(x, e2 = 8) })
+  )
+})
+
+## Other tests ----
+test_that("detect() and detect_index() force arguments", {
+  test_if_is <- function(f) f(1)
+  expect_identical(detect(list(is.integer, is.numeric), test_if_is), is.numeric)
+  expect_identical(detect_index(list(is.integer, is.numeric), test_if_is), 2L)
+})
+
+# has_element() ----------------------------------------------------------------
+
+test_that("has_element() checks whether a list contains an object", {
   expect_true(has_element(list(1, 2), 1))
   expect_false(has_element(list(1, 2), 3))
-})
-
-test_that("`detect()` requires a predicate function", {
-  expect_snapshot(detect(list(1:2, 2), is.na), error = TRUE)
-  expect_snapshot(detect_index(list(1:2, 2), is.na), error = TRUE)
 })

--- a/tests/testthat/test-head-tail.R
+++ b/tests/testthat/test-head-tail.R
@@ -1,11 +1,16 @@
 y <- 1:100
 
-test_that("head_while works", {
-  expect_length(head_while(y, function(x) x <= 15), 15)
+## Basic tests ----
+test_that("head_while() works", {
+  out <- head_while(y, function(x) x <= 15)
+  expect_length(out, 15)
+  expect_identical(out, 1:15)
 })
 
-test_that("tail_while works", {
-  expect_length(tail_while(y, function(x) x >= 86), 15)
+test_that("tail_while() works", {
+  out <- tail_while(y, function(x) x >= 86)
+  expect_length(out, 15)
+  expect_identical(out, 86:100)
 })
 
 test_that("original vector returned if predicate satisfied by all elements", {
@@ -13,7 +18,107 @@ test_that("original vector returned if predicate satisfied by all elements", {
   expect_identical(tail_while(y, function(x) x >= 0), y)
 })
 
-test_that("head_while and tail_while require predicate function", {
-  expect_snapshot(head_while(1:3, ~NA), error = TRUE)
-  expect_snapshot(tail_while(1:3, ~ c(TRUE, FALSE)), error = TRUE)
+## Empty size behavior ----
+test_that("head_while() and tail_while() have correct empty size behavior", {
+  # No elements to fail the check
+  expect_identical(head_while(list(), identity), list())
+  expect_identical(tail_while(list(), identity), list())
+})
+
+test_that("head_while() and tail_while() work on `NULL`", {
+  # No elements to fail the check
+  expect_null(head_while(NULL, identity))
+  expect_null(tail_while(NULL, identity))
+})
+
+## .f requirements ----
+test_that("head_while() and tail_while() require boolean results", {
+  # No coercion to `TRUE` or `FALSE`
+  expect_snapshot(head_while(list(1), function(x) 1), error = TRUE)
+  expect_snapshot(tail_while(list(1), function(x) 1), error = TRUE)
+
+  # `NA` is not allowed whatsoever
+  expect_snapshot(head_while(list(1), function(x) NA), error = TRUE)
+  expect_snapshot(tail_while(list(1), function(x) NA), error = TRUE)
+
+  # Must be length 1
+  expect_snapshot(head_while(list(1), function(x) c(TRUE, FALSE)), error = TRUE)
+  expect_snapshot(tail_while(list(1), function(x) c(TRUE, FALSE)), error = TRUE)
+
+  # Attributes are allowed, we ignore them
+  expect_equal(head_while(list(1), function(x) structure(TRUE, foo = "bar")), list(1))
+  expect_equal(tail_while(list(1), function(x) structure(TRUE, foo = "bar")), list(1))
+
+  # Classes are allowed for historical reasons.
+  # We probably wouldn't consider these to be logical scalars these days.
+  expect_equal(head_while(list(1), function(x) structure(TRUE, class = "mylgl")), list(1))
+  expect_equal(tail_while(list(1), function(x) structure(TRUE, class = "mylgl")), list(1))
+
+  # We bypass any S3 `length()` methods!
+  local_methods(length.mylgl = function(x) 2L)
+  expect_equal(head_while(list(1), function(x) structure(TRUE, class = "mylgl")), list(1))
+  expect_equal(tail_while(list(1), function(x) structure(TRUE, class = "mylgl")), list(1))
+})
+
+## .x requirements ----
+test_that("head_while() and tail_while() require vector `.x`", {
+  expect_snapshot(head_while(function() 1, identity), error = TRUE)
+  expect_snapshot(tail_while(function() 1, identity), error = TRUE)
+})
+
+test_that("head_while() and tail_while() work colwise across data frames", {
+  # If it naively worked off `vec_size()` then extracted elements with `[[`,
+  # this would return incorrect results. This definition is consistent with
+  # `map()`.
+  df <- data_frame(a = 1L, b = 2)
+  expect_identical(head_while(df, is.integer), df["a"])
+  expect_identical(tail_while(df, is.double), df["b"])
+})
+
+test_that("head_while() and tail_while() work on list scalars", {
+  # For consistency with `map()`
+  obj <- structure(list(1, "x"), class = "my_scalar")
+  expect_identical(head_while(obj, is.double), list(1))
+  expect_identical(tail_while(obj, is.character), list("x"))
+})
+
+test_that("head_while() and tail_while() work with vctrs records", {
+  x <- new_rcrd(list(x = c(1, 2, 3), y = c("a", "b", "c")))
+
+  out <- list()
+  head_while(x, function(elt) {
+    out <<- append(out, list(elt))
+    TRUE
+  })
+  expect_identical(out, vec_chop(x))
+
+  out <- list()
+  tail_while(x, function(elt) {
+    out <<- append(out, list(elt))
+    TRUE
+  })
+  expect_identical(out, rev(vec_chop(x)))
+})
+
+## ... tests ----
+test_that("head_while() and tail_while() pass ... to function", {
+  exceeds <- function(e1, e2) e1 > e2
+
+  expect_identical(
+    head_while(y, negate(exceeds), e2 = 8),
+    head_while(y, function(x) { negate(exceeds)(x, e2 = 8) })
+  )
+  expect_identical(
+    tail_while(y, exceeds, e2 = 91),
+    tail_while(y, function(x) { exceeds(x, e2 = 91) })
+  )
+})
+
+## Other tests ----
+test_that("head_while() and tail_while() force arguments", {
+  funcs <- list(is.integer, is.numeric, is.character, is.vector)
+  test_if_is <- function(f) f(1L)
+
+  expect_identical(head_while(funcs, test_if_is), funcs[1:2])
+  expect_identical(tail_while(funcs, test_if_is), funcs[4])
 })


### PR DESCRIPTION
I saw `as_predicate()` + `for`-loop, I had to have a go at it 🦔 

I rewrote `detect_index()` as `which_satisfies_predicate()` in C. It's very similar to `satisfies_predicate()` powering `every()` and friends, and at one point I thought about making one shared implementation for these, as both these families look for the first element that behaves differently to the previous ones in a predicate. I'd just change `every()` and friends to test the index against 0.

However, the differences were too numerous:
* `detect_index()` doesn't allow `NA`, while `every()` propagates it;
* `detect_index()` allows setting backward direction, while `every()` doesn't;
* `detect_index()` names its predicate parameter `.f` (historical leftover, I assume), while `every()` has `.p`.

Therefore, I kept them separate. Also, regarding the last point, I had to handle that anyway due to `head_while()` and `tail_while()` having `.p` as well.

There's a lot of ideas shared with `every()` in R as well, `which_satisfies_predicate()` in R follows very similar logic as `satisfies_predicate()`, replacing `as_predicate()` with `as_mapper()` and performing bool check in R in particular. This bool check doesn't test for attributes nor classes, just like the analogous scalar logical check in `every()`.

You will see the `.negate` argument to `which_satisfies_predicate()`. The reason for that is for optimal handling of `head_while()` and `tail_while()` which look for the first element _not_ satisfying a predicate. They had `negate(as_predicate())` before, but that was _very_ costly (you'll see how much in the benchmark) and had to go. But I couldn't (obviously) negate `.p` directly, and the `as_mapper()` call only took part inside `which_satisfies_predicate()`, so... I moved it completely inside C, so that there's even less overhead.

Most test cases were adapted from `every()`, so that they should cover most weird inputs in here as well.

----

As for the reason for this C rewrite - `detect_index()` and `detect()` are now about three times faster:

``` r
cross::bench_branches({
  x <- 5e5:-1
  is_negative <- \(x) x < 0
  
  bench::mark(purrr::detect_index(x, is_negative), iterations = 10)
})
#> # A tibble: 2 × 14
#>   branch  expression   min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory     time      
#>   <chr>   <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>     <list>    
#> 1 optimi… purrr::de… 249ms  286ms      3.48     733KB     50.4    10   145      2.88s <int>  <Rprofmem> <bench_tm>
#> 2 main    purrr::de… 777ms  842ms      1.19     797KB     30.5    10   257      8.43s <int>  <Rprofmem> <bench_tm>
# ℹ 1 more variable: gc <list>

cross::bench_branches({
  x <- 5e5:-1
  is_negative <- \(x) x < 0
  
  bench::mark(purrr::detect(x, is_negative), iterations = 10)
})
#> # A tibble: 2 × 14
#>   branch  expression   min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory     time      
#>   <chr>   <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>     <list>    
#> 1 optimi… purrr::de… 246ms  300ms      3.50     735KB     50.8    10   145      2.85s <int>  <Rprofmem> <bench_tm>
#> 2 main    purrr::de… 791ms  824ms      1.21     797KB     31.0    10   257       8.3s <int>  <Rprofmem> <bench_tm>
# ℹ 1 more variable: gc <list>
```

<sup>Created on 2026-02-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The real difference is in `head_while()` and `tail_while()`, though. The first time I ran the benchmark, I went to fix the number of iterations, because I thought I rolled a very slow execution of the current implementation. I expected a speedup factor of three, like above, but instead, I got 25:

``` r
cross::bench_branches({
  x <- 2e5:-1
  is_positive <- \(x) x > 0
  
  bench::mark(purrr::head_while(x, is_positive), iterations = 10)
})
#> # A tibble: 2 × 14
#>   branch        expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory    
#>   <chr>         <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>    
#> 1 optimize-det… purrr::he… 107.29ms 113.14ms     8.45     2.24MB     83.6    10    99      1.18s <int>  <Rprofmem>
#> 2 main          purrr::he…    2.58s    2.74s     0.362   56.17MB     10.1    10   278     27.61s <int>  <Rprofmem>
# ℹ 2 more variables: time <list>, gc <list>
```

<sup>Created on 2026-02-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

~As with all my other PRs (I'm starting to feel guilty about all these code reviews!), the last commit updates snaps to vctrs v0.7.0 and can be safely removed if necessary.~