### PR TITLE
Fix deprecated C API for CRAN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # purrr (development version)
 
-* Fixes for CRAN checks.
+* Fixes for CRAN checks (@ErdaradunGaztea, #1256).
 
 # purrr 1.2.1
 
@@ -41,7 +41,7 @@
 * purrr now requires R >= 4.1, so we can rely on the base pipe and lambda
   syntax (#1177).
 
-* purrr gains `in_parallel()` to support parallel and distributed maps, powered 
+* purrr gains `in_parallel()` to support parallel and distributed maps, powered
   by {mirai}. See `?in_parallel` for more details (@shikokuchuo, #1163, #1185).
 
 # purrr 1.0.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* Fixes for CRAN checks.
+
 # purrr 1.2.1
 
 * Tweaks for compatibility with upcoming vctrs 0.7.0.

--- a/src/cleancall.c
+++ b/src/cleancall.c
@@ -2,6 +2,7 @@
 #include <Rinternals.h>
 
 #include "cleancall.h"
+#include "utils.h"
 
 
 #if (defined(R_VERSION) && R_VERSION < R_Version(3, 4, 0))
@@ -14,23 +15,6 @@
    fn_ptr ptr;
    ptr.p = R_ExternalPtrAddr(s);
    return ptr.fn;
- }
-#endif
-
-#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
- SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits) {
-   SEXP out;
-   if (inherits) {
-     out = Rf_findVar(symbol, rho);
-   } else {
-     out = Rf_findVarInFrame(rho, symbol);
-   }
-
-   if (out == R_UnboundValue) {
-     const char *name = CHAR(PRINTNAME(symbol));
-     Rf_error("object '%s' not found", name);
-   }
-   return out;
  }
 #endif
 

--- a/src/cleancall.c
+++ b/src/cleancall.c
@@ -17,6 +17,23 @@
  }
 #endif
 
+#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
+ SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits) {
+   SEXP out;
+   if (inherits) {
+     out = Rf_findVar(symbol, rho);
+   } else {
+     out = Rf_findVarInFrame(rho, symbol);
+   }
+
+   if (out == R_UnboundValue) {
+     const char *name = CHAR(PRINTNAME(symbol));
+     Rf_error("object '%s' not found", name);
+   }
+   return out;
+ }
+#endif
+
 // The R API does not have a setter for function pointers
 
 SEXP cleancall_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot) {
@@ -38,7 +55,7 @@ SEXP cleancall_fns_dot_call = NULL;
 static SEXP callbacks = NULL;
 
 void cleancall_init(void) {
-  cleancall_fns_dot_call = Rf_findVar(Rf_install(".Call"), R_BaseEnv);
+  cleancall_fns_dot_call = R_getVar(Rf_install(".Call"), R_BaseEnv, TRUE);
   callbacks = R_NilValue;
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -9,6 +9,8 @@
 
 #include "cleancall.h"
 
+extern void unbound_init(void);
+
 /* .Call calls */
 extern SEXP coerce_impl(SEXP, SEXP);
 extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP);
@@ -44,4 +46,5 @@ export void R_init_purrr(DllInfo *dll)
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
     cleancall_init();
+    unbound_init();
 }

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -12,7 +12,7 @@ static int check_double_index_finiteness(double val, SEXP index, int i, bool str
 static int check_double_index_length(double val, int n, int i, bool strict);
 static int check_character_index(SEXP string, int i, bool strict);
 static int check_names(SEXP names, int i, bool strict);
-static int check_unbound_value(SEXP val, SEXP index_i, bool strict);
+
 static int check_s4_slot(SEXP val, SEXP index_i, bool strict);
 static int check_obj_length(SEXP n, bool strict);
 
@@ -141,7 +141,7 @@ SEXP extract_vector(SEXP x, SEXP index_i, int i, bool strict) {
 
 static SEXP unbound = NULL;
 
-void unbound_init() {
+void unbound_init(void) {
   unbound = Rf_install(".__purrr_unbound__.");
 }
 
@@ -159,12 +159,18 @@ SEXP extract_env(SEXP x, SEXP index_i, int i, bool strict) {
   }
 
   SEXP sym = Rf_installChar(index);
-  SEXP out = R_getVarEx(sym, x, FALSE, unbound);
 
-  if (check_unbound_value(out, index_i, strict)) {
-    return R_NilValue;
+  if (!strict) {
+    return R_getVarEx(sym, x, FALSE, R_NilValue);
   }
 
+  SEXP out = R_getVarEx(sym, x, FALSE, unbound);
+  if (out == unbound) {
+    r_abort(
+      "Can't find object `%s` in environment.",
+      Rf_translateCharUTF8(Rf_asChar(index_i))
+    );
+  }
   return out;
 }
 
@@ -355,21 +361,6 @@ static int check_names(SEXP names, int i, bool strict) {
   }
 }
 
-static int check_unbound_value(SEXP val, SEXP index_i, bool strict) {
-  if (val != unbound) {
-    return 0;
-  }
-
-  if (strict) {
-    r_abort(
-      "Can't find object `%s` in environment.",
-      Rf_translateCharUTF8(Rf_asChar(index_i))
-    );
-  } else {
-    return -1;
-  }
-}
-
 static int check_s4_slot(SEXP val, SEXP index_i, bool strict) {
   if (R_has_slot(val, index_i)) {
     return 0;
@@ -396,7 +387,6 @@ static int check_obj_length(SEXP n, bool strict) {
 
   return 0;
 }
-
 
 int obj_length(SEXP x, bool strict) {
   if (!Rf_isObject(x)) {

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -139,6 +139,12 @@ SEXP extract_vector(SEXP x, SEXP index_i, int i, bool strict) {
   return R_NilValue;
 }
 
+static SEXP unbound = NULL;
+
+void unbound_init() {
+  unbound = Rf_install(".__purrr_unbound__.");
+}
+
 SEXP extract_env(SEXP x, SEXP index_i, int i, bool strict) {
   if (TYPEOF(index_i) != STRSXP) {
     stop_bad_element_type(index_i, i + 1, "a string", "Index", NULL);
@@ -153,7 +159,7 @@ SEXP extract_env(SEXP x, SEXP index_i, int i, bool strict) {
   }
 
   SEXP sym = Rf_installChar(index);
-  SEXP out = R_getVarEx(sym, x, FALSE, R_UnboundValue);
+  SEXP out = R_getVarEx(sym, x, FALSE, unbound);
 
   if (check_unbound_value(out, index_i, strict)) {
     return R_NilValue;
@@ -350,7 +356,7 @@ static int check_names(SEXP names, int i, bool strict) {
 }
 
 static int check_unbound_value(SEXP val, SEXP index_i, bool strict) {
-  if (val != R_UnboundValue) {
+  if (val != unbound) {
     return 0;
   }
 

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -6,18 +6,7 @@
 #include "backports.h"
 #include "coerce.h"
 #include "conditions.h"
-
-#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
- SEXP R_getVarEx(SEXP symbol, SEXP rho, Rboolean inherits, SEXP ifnotfound) {
-   SEXP out;
-   if (inherits) {
-     out = Rf_findVar(symbol, rho);
-   } else {
-     out = Rf_findVarInFrame(rho, symbol);
-   }
-   return out == R_UnboundValue ? ifnotfound : out;
- }
-#endif
+#include "utils.h"
 
 static int check_double_index_finiteness(double val, SEXP index, int i, bool strict);
 static int check_double_index_length(double val, int n, int i, bool strict);

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -7,6 +7,18 @@
 #include "coerce.h"
 #include "conditions.h"
 
+#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
+ SEXP R_getVarEx(SEXP symbol, SEXP rho, Rboolean inherits, SEXP ifnotfound) {
+   SEXP out;
+   if (inherits) {
+     out = Rf_findVar(symbol, rho);
+   } else {
+     out = Rf_findVarInFrame(rho, symbol);
+   }
+   return out == R_UnboundValue ? ifnotfound : out;
+ }
+#endif
+
 static int check_double_index_finiteness(double val, SEXP index, int i, bool strict);
 static int check_double_index_length(double val, int n, int i, bool strict);
 static int check_character_index(SEXP string, int i, bool strict);
@@ -152,7 +164,7 @@ SEXP extract_env(SEXP x, SEXP index_i, int i, bool strict) {
   }
 
   SEXP sym = Rf_installChar(index);
-  SEXP out = Rf_findVarInFrame(x, sym);
+  SEXP out = R_getVarEx(sym, x, FALSE, R_UnboundValue);
 
   if (check_unbound_value(out, index_i, strict)) {
     return R_NilValue;

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,12 +15,7 @@
  }
 
  SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits) {
-   SEXP out;
-   if (inherits) {
-     out = Rf_findVar(symbol, rho);
-   } else {
-     out = Rf_findVarInFrame(rho, symbol);
-   }
+   SEXP out = R_getVarEx(symbol, rho, inherits, R_UnboundValue);
 
    if (out == R_UnboundValue) {
      const char *name = CHAR(PRINTNAME(symbol));

--- a/src/utils.c
+++ b/src/utils.c
@@ -11,6 +11,16 @@
    } else {
      out = Rf_findVarInFrame(rho, symbol);
    }
+
+   if (out == R_MissingArg) {
+     const char *name = CHAR(PRINTNAME(symbol));
+     Rf_error("argument \"%s\" is missing, with no default", name);
+   }
+
+   if (TYPEOF(out) == PROMSXP) {
+     return PRVALUE(out);
+   }
+
    return out == R_UnboundValue ? ifnotfound : out;
  }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -12,16 +12,22 @@
      out = Rf_findVarInFrame(rho, symbol);
    }
 
+   if (out == R_UnboundValue) {
+     return ifnotfound;
+   }
+
    if (out == R_MissingArg) {
      const char *name = CHAR(PRINTNAME(symbol));
      Rf_error("argument \"%s\" is missing, with no default", name);
    }
 
    if (TYPEOF(out) == PROMSXP) {
-     return PRVALUE(out);
+     PROTECT(out);
+     out = Rf_eval(out, R_BaseEnv);
+     UNPROTECT(1);
    }
 
-   return out == R_UnboundValue ? ifnotfound : out;
+   return out;
  }
 
  SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,6 +1,34 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
 #include <stdbool.h>
+#include <Rversion.h>
+
+#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
+ SEXP R_getVarEx(SEXP symbol, SEXP rho, Rboolean inherits, SEXP ifnotfound) {
+   SEXP out;
+   if (inherits) {
+     out = Rf_findVar(symbol, rho);
+   } else {
+     out = Rf_findVarInFrame(rho, symbol);
+   }
+   return out == R_UnboundValue ? ifnotfound : out;
+ }
+
+ SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits) {
+   SEXP out;
+   if (inherits) {
+     out = Rf_findVar(symbol, rho);
+   } else {
+     out = Rf_findVarInFrame(rho, symbol);
+   }
+
+   if (out == R_UnboundValue) {
+     const char *name = CHAR(PRINTNAME(symbol));
+     Rf_error("object '%s' not found", name);
+   }
+   return out;
+ }
+#endif
 
 SEXP sym_protect(SEXP x) {
   if (TYPEOF(x) == LANGSXP || TYPEOF(x) == SYMSXP) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,7 +2,13 @@
 #define UTILS_H
 
 #include <stdbool.h>
+#include <Rversion.h>
 
+
+#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
+ SEXP R_getVarEx(SEXP symbol, SEXP rho, Rboolean inherits, SEXP ifnotfound);
+ SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits);
+#endif
 
 SEXP sym_protect(SEXP x);
 

--- a/tests/testthat/_snaps/every-some-none.md
+++ b/tests/testthat/_snaps/every-some-none.md
@@ -77,6 +77,7 @@
     Condition
       Error in `every()`:
       ! `.x` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 ---
 
@@ -85,6 +86,7 @@
     Condition
       Error in `some()`:
       ! `.x` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 ---
 
@@ -93,6 +95,7 @@
     Condition
       Error in `none()`:
       ! `.x` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 # pairlists, expressions, and calls are deprecated but work
 

--- a/tests/testthat/_snaps/list-simplify.md
+++ b/tests/testthat/_snaps/list-simplify.md
@@ -21,6 +21,7 @@
     Condition
       Error in `list_simplify()`:
       ! `x[[1]]` must be a vector, not a function.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
     Code
       list_simplify(list(1, "a"))
     Condition

--- a/tests/testthat/_snaps/map.md
+++ b/tests/testthat/_snaps/map.md
@@ -5,6 +5,7 @@
     Condition
       Error in `map()`:
       ! `.x` must be a vector, not an environment.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 ---
 
@@ -13,6 +14,7 @@
     Condition
       Error in `map()`:
       ! `.x` must be a vector, not a symbol.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 # all inform about location of problem
 

--- a/tests/testthat/_snaps/map2.md
+++ b/tests/testthat/_snaps/map2.md
@@ -27,11 +27,13 @@
     Condition
       Error in `map2()`:
       ! `.x` must be a vector, not an environment.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
     Code
       map2("a", environment(), "a", identity)
     Condition
       Error in `map2()`:
       ! `.y` must be a vector, not an environment.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 # recycles inputs
 

--- a/tests/testthat/_snaps/modify.md
+++ b/tests/testthat/_snaps/modify.md
@@ -28,6 +28,9 @@
     Condition
       Error in `map_vec()`:
       ! `out[[1]]` must be a vector, not a <rlang_zap> object.
+      x Detected incompatible scalar S3 list. To be treated as a vector, the object must explicitly inherit from <list> or should implement a `vec_proxy()` method. Class: <rlang_zap>.
+      i If this object comes from a package, please report this error to the package author.
+      i Read our FAQ about creating vector types (`?vctrs::howto_faq_fix_scalar_type_error`) to learn more.
     Code
       modify_at(list(1), 1, ~ zap())
     Condition

--- a/tests/testthat/_snaps/parallel.md
+++ b/tests/testthat/_snaps/parallel.md
@@ -111,11 +111,13 @@
     Condition
       Error in `map2()`:
       ! `.x` must be a vector, not an environment.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
     Code
       map2("a", environment(), "a", in_parallel(function(x) identity(x)))
     Condition
       Error in `map2()`:
       ! `.y` must be a vector, not an environment.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 # recycles inputs
 
@@ -155,4 +157,5 @@
     Condition
       Error in `pmap()`:
       ! `.l[[1]]` must be a vector, not an environment.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 

--- a/tests/testthat/_snaps/pmap.md
+++ b/tests/testthat/_snaps/pmap.md
@@ -32,6 +32,7 @@
     Condition
       Error in `pmap()`:
       ! `.l[[1]]` must be a vector, not an environment.
+      i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
 
 # recycles inputs
 

--- a/tests/testthat/test-pluck.R
+++ b/tests/testthat/test-pluck.R
@@ -207,12 +207,10 @@ test_that("environments error with invalid indices", {
   expect_snapshot(pluck(environment(), letters), error = TRUE)
 })
 
-test_that("plucking promise from an environment returns the unevaluated promise", {
+test_that("plucking promise from an environment evaluates it", {
   x <- new_environment()
   delayedAssign("q", { 1 }, assign.env = x)
-
-  # Can't use expect_type(..., "promise") because labelled_value() inside it forces promise evaluation
-  expect_true(inherits_only(pluck(x, "q"), "promise"))
+  expect_equal(pluck(x, "q"), 1)
 })
 
 # S4 ----------------------------------------------------------------------

--- a/tests/testthat/test-pluck.R
+++ b/tests/testthat/test-pluck.R
@@ -207,6 +207,14 @@ test_that("environments error with invalid indices", {
   expect_snapshot(pluck(environment(), letters), error = TRUE)
 })
 
+test_that("plucking promise from an environment returns the unevaluated promise", {
+  x <- new_environment()
+  delayedAssign("q", { 1 }, assign.env = x)
+
+  # Can't use expect_type(..., "promise") because labelled_value() inside it forces promise evaluation
+  expect_true(inherits_only(pluck(x, "q"), "promise"))
+})
+
 # S4 ----------------------------------------------------------------------
 
 newA <- methods::setClass("A", list(a = "numeric"))


### PR DESCRIPTION
With the upcoming R 4.6.0, `Rf_findVar()` and `Rf_findVarInFrame()` will be deprecated and raise warnings (like in the currently failing CRAN checks). Starting with R 4.5.0, there are two functions -- `R_getVar()` and `R_getVarEx()` -- that are meant to replace them, as per "Writing R Extensions":

<img width="602" height="78" alt="image" src="https://github.com/user-attachments/assets/b0e1c9dd-7b61-4804-8616-94850bca7458" />

The difference is that `R_getVar()` raises an error if symbol not found, and `R_getVarEx()` returns a specified default value instead. Since both previous functions returned `R_UnboundValue` if symbol not found, technically, a drop-in replacement would be:

| before | after |
|---|---|
| `Rf_findVar(symbol, env)` | `R_getVarEx(symbol, env, TRUE, R_UnboundValue)` |
| `Rf_findVarInFrame(env, symbol)` | `R_getVarEx(symbol, env, FALSE, R_UnboundValue)` |

For **cleancall.c** and its extraction of `.Call` though, it's better to use `R_getVar()`, as we would rather get an error if `.Call` is missing (and, honestly, the user would have much more pressing problems if it was indeed missing).

I've created a conditional define block in C for R < 4.5.0, since that's when these two new functions were introduced, but defining for R < 4.6.0 would also work.

PS. As with all my other PRs, I've updated test snaps to vctrs v0.7.0.