### PR TITLE
docs: describe list_cbind named inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # purrr (development version)
 
+* `list_cbind()` documentation now describes how named inputs can create packed
+  data frame columns and points to `unname()` when those outer names should be
+  ignored (#1080, @LeonidasZhak).
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/R/list-combine.R
+++ b/R/list-combine.R
@@ -8,7 +8,9 @@
 #'   together with [vctrs::vec_rbind()].
 #'
 #' * `list_cbind()` combines elements into a data frame by column-binding them
-#'   together with [vctrs::vec_cbind()].
+#'   together with [vctrs::vec_cbind()]. If `x` is named, those names are used
+#'   by [vctrs::vec_cbind()] and may create packed data frame columns. Use
+#'   `unname(x)` to avoid this.
 #'
 #' @param x A list. For `list_rbind()` and `list_cbind()` the list must
 #'   only contain only data frames or `NULL`.
@@ -37,6 +39,7 @@
 #' list_rbind(unname(x2), names_to = "id")
 #'
 #' list_cbind(x2)
+#' list_cbind(unname(x2))
 list_c <- function(x, ..., ptype = NULL) {
   obj_check_list(x)
   check_dots_empty()

--- a/man/list_c.Rd
+++ b/man/list_c.Rd
@@ -44,7 +44,9 @@ with \code{\link[vctrs:vec_c]{vctrs::vec_c()}}.
 \item \code{list_rbind()} combines elements into a data frame by row-binding them
 together with \code{\link[vctrs:vec_bind]{vctrs::vec_rbind()}}.
 \item \code{list_cbind()} combines elements into a data frame by column-binding them
-together with \code{\link[vctrs:vec_bind]{vctrs::vec_cbind()}}.
+together with \code{\link[vctrs:vec_bind]{vctrs::vec_cbind()}}. If \code{x} is named, those names are used
+by \code{\link[vctrs:vec_bind]{vctrs::vec_cbind()}} and may create packed data frame columns. Use
+\code{unname(x)} to avoid this.
 }
 }
 \examples{
@@ -60,4 +62,5 @@ list_rbind(x2, names_to = "id")
 list_rbind(unname(x2), names_to = "id")
 
 list_cbind(x2)
+list_cbind(unname(x2))
 }


### PR DESCRIPTION
Fixes #1080.

## Summary
- clarify that named inputs to `list_cbind()` are passed through to `vctrs::vec_cbind()`
- mention that those names can create packed data frame columns
- add `list_cbind(unname(x2))` to the examples as the way to ignore outer names

## Checks
- `Rscript -e 'tools::checkRd("man/list_c.Rd")'`\n- `git diff --check`\n- `Rscript -e 'library(purrr); x2 <- list(a = data.frame(x = 1:2), b = data.frame(y = "a")); out <- list_cbind(unname(x2)); stopifnot(identical(names(out), c("x", "y")), nrow(out) == 2L)'`\n- `R CMD build --no-build-vignettes .`