### PR TITLE
Fix typo in description of `.l`

### DIFF
--- a/R/pmap.R
+++ b/R/pmap.R
@@ -7,7 +7,7 @@
 #' they share the same notion of "parallel" as [base::pmax()] and [base::pmin()].
 #'
 #' @param .l A list of vectors. The length of `.l` determines the number of
-#'   arguments that `.f` will be called with. Arguments will be supply by
+#'   arguments that `.f` will be called with. Arguments will be supplied by
 #'   position if unnamed, and by name if named.
 #'
 #'   Vectors of length 1 will be recycled to any length; all other elements


### PR DESCRIPTION
"will be supply" → "will be supplied"