### PR TITLE
Rework `map()` family internals for performance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* All `map()` functions now have less overhead, particularly on unclassed vectors. This means that they should run faster when `.f` itself is very fast, like with the common cases of `map(x, names)` or `map_lgl(x, is.null)` (#1263, with an assist from @ErdaradunGaztea).
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/R/map.R
+++ b/R/map.R
@@ -221,7 +221,16 @@ map_ <- function(
     i = i,
     names = names,
     error_call = .purrr_error_call,
-    call_with_cleanup(map_impl, environment(), .type, .progress, n, names, i)
+    call_with_cleanup(
+      map_impl,
+      .x,
+      environment(),
+      .type,
+      .progress,
+      n,
+      names,
+      i
+    )
   )
 }
 

--- a/R/map2.R
+++ b/R/map2.R
@@ -105,7 +105,17 @@ map2_ <- function(
     i = i,
     names = names,
     error_call = .purrr_error_call,
-    call_with_cleanup(map2_impl, environment(), .type, .progress, n, names, i)
+    call_with_cleanup(
+      map2_impl,
+      .x,
+      .y,
+      environment(),
+      .type,
+      .progress,
+      n,
+      names,
+      i
+    )
   )
 }
 

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -165,9 +165,6 @@ pmap_ <- function(
     return(mmap_(.l, .f, .progress, .type, .purrr_error_call, ...))
   }
 
-  call_names <- names(.l)
-  call_n <- length(.l)
-
   i <- 0L
   with_indexed_errors(
     i = i,
@@ -175,14 +172,13 @@ pmap_ <- function(
     error_call = .purrr_error_call,
     call_with_cleanup(
       pmap_impl,
+      .l,
       environment(),
       .type,
       .progress,
       n,
       names,
-      i,
-      call_names,
-      call_n
+      i
     )
   )
 }

--- a/src/init.c
+++ b/src/init.c
@@ -10,6 +10,7 @@
 #include "cleancall.h"
 
 extern void unbound_init(void);
+extern void map_init(void);
 
 /* .Call calls */
 extern SEXP coerce_impl(SEXP, SEXP);
@@ -18,9 +19,9 @@ extern SEXP flatten_impl(SEXP);
 extern SEXP every_impl(SEXP, SEXP, SEXP);
 extern SEXP some_impl(SEXP, SEXP, SEXP);
 extern SEXP none_impl(SEXP, SEXP, SEXP);
-extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP transpose_impl(SEXP, SEXP);
 extern SEXP vflatten_impl(SEXP, SEXP);
 
@@ -32,9 +33,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"every_impl",            (DL_FUNC) &every_impl,     3},
   {"some_impl",             (DL_FUNC) &some_impl,      3},
   {"none_impl",             (DL_FUNC) &none_impl,      3},
-  {"map_impl",              (DL_FUNC) &map_impl,       6},
-  {"map2_impl",             (DL_FUNC) &map2_impl,      6},
-  {"pmap_impl",             (DL_FUNC) &pmap_impl,      8},
+  {"map_impl",              (DL_FUNC) &map_impl,       7},
+  {"map2_impl",             (DL_FUNC) &map2_impl,      8},
+  {"pmap_impl",             (DL_FUNC) &pmap_impl,      7},
   {"transpose_impl",        (DL_FUNC) &transpose_impl, 2},
   {"vflatten_impl",         (DL_FUNC) &vflatten_impl,  2},
   {"purrr_eval",            (DL_FUNC) &Rf_eval,        2},
@@ -47,4 +48,5 @@ export void R_init_purrr(DllInfo *dll)
     R_useDynamicSymbols(dll, FALSE);
     cleancall_init();
     unbound_init();
+    map_init();
 }

--- a/src/map.c
+++ b/src/map.c
@@ -3,7 +3,6 @@
 #include <Rversion.h>
 #include <Rinternals.h>
 #include "coerce.h"
-#include "conditions.h"
 #include "utils.h"
 
 // Including <cli/progress.h> before "cleancall.h" because we want to register
@@ -11,22 +10,36 @@
 #include <cli/progress.h>
 #include "cleancall.h"
 
-static
-void cb_progress_done(void* bar_ptr) {
+static SEXP sym_i = NULL;
+static SEXP sym_dot_f = NULL;
+static SEXP sym_dot_x = NULL;
+static SEXP sym_dot_y = NULL;
+static SEXP sym_dot_x_i = NULL;
+static SEXP sym_dot_y_i = NULL;
+
+static SEXP call_dot_x_subset2_i = NULL;
+static SEXP call_dot_y_subset2_i = NULL;
+
+static SEXP call_map = NULL;
+static SEXP call_map2 = NULL;
+
+static int force_map = 1;
+static int force_map2 = 2;
+
+static void cb_progress_done(void* bar_ptr) {
   SEXP bar = (SEXP)bar_ptr;
   cli_progress_done(bar);
   R_ReleaseObject(bar);
 }
 
-// call must involve i
-SEXP call_loop(SEXP env,
-               SEXP call,
-               SEXPTYPE type,
-               SEXP progress,
-               int n,
-               SEXP names,
-               int* p_i,
-               int force) {
+static inline SEXP call_loop(
+  const void* p_data,
+  SEXP (*fn_exec)(const void* p_data, int i),
+  SEXPTYPE type,
+  SEXP progress,
+  int n,
+  SEXP names
+) {
   SEXP bar = cli_progress_bar(n, progress);
   R_PreserveObject(bar);
   r_call_on_exit((void (*)(void*)) cb_progress_done, (void*) bar);
@@ -35,8 +48,6 @@ SEXP call_loop(SEXP env,
   Rf_setAttrib(out, R_NamesSymbol, names);
 
   for (int i = 0; i < n; ++i) {
-    *p_i = i + 1;
-
     if (CLI_SHOULD_TICK) {
       cli_progress_set(bar, i);
     }
@@ -44,7 +55,7 @@ SEXP call_loop(SEXP env,
       R_CheckUserInterrupt();
     }
 
-    SEXP res = PROTECT(R_forceAndCall(call, force, env));
+    SEXP res = PROTECT(fn_exec(p_data, i));
 
     if (type != VECSXP && Rf_length(res) != 1) {
       Rf_errorcall(R_NilValue, "Result must be length 1, not %i.", Rf_length(res));
@@ -54,159 +65,296 @@ SEXP call_loop(SEXP env,
     UNPROTECT(1);
   }
 
-  *p_i = 0;
-
   UNPROTECT(1);
   return out;
 }
 
-SEXP map_impl(SEXP env,
-              SEXP ffi_type,
-              SEXP progress,
-              SEXP ffi_n,
-              SEXP names,
-              SEXP i) {
-  static SEXP call = NULL;
-  if (call == NULL) {
-    SEXP x_sym = Rf_install(".x");
-    SEXP f_sym = Rf_install(".f");
-    SEXP i_sym = Rf_install("i");
+struct map_exec_data {
+  SEXP x;
+  const void* v_x;
+  SEXPTYPE x_type;
+  bool x_object;
 
-    // Constructs a call like f(x[[i]], ...) - don't want to substitute
-    // actual values for f or x, because they may be long, which creates
-    // bad tracebacks()
-    SEXP x_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, x_sym, i_sym));
+  int* v_i;
+  SEXP env;
+};
 
-    call = Rf_lang3(f_sym, x_i_sym, R_DotsSymbol);
-    R_PreserveObject(call);
+struct map2_exec_data {
+  SEXP x;
+  const void* v_x;
+  SEXPTYPE x_type;
+  bool x_object;
 
-    UNPROTECT(1);
-  }
+  SEXP y;
+  const void* v_y;
+  SEXPTYPE y_type;
+  bool y_object;
 
-  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
-  int n = INTEGER_ELT(ffi_n, 0);
-  int* p_i = INTEGER(i);
-  int force = 1;
+  int* v_i;
+  SEXP env;
+};
 
-  return call_loop(
-    env,
-    call,
-    type,
-    progress,
-    n,
-    names,
-    p_i,
-    force
-  );
+struct pmap_elt {
+  SEXP elt;
+  const void* v_elt;
+  SEXPTYPE elt_type;
+  bool elt_object;
+
+  // .l_{elt}_i
+  SEXP sym_elt_i;
+  // .l_{elt}[[i]]
+  SEXP call_elt_subset2_i;
+};
+
+struct pmap_exec_data {
+  const struct pmap_elt* v_l;
+  int n_l;
+
+  // .f(.l_1_i, .l_2_i, .l_3_i, ...)
+  SEXP call_pmap;
+  int force_pmap;
+
+  int* v_i;
+  SEXP env;
+};
+
+static inline SEXP map_exec(const void* p_data_void, int i) {
+  const struct map_exec_data* p_data = (const struct map_exec_data*) p_data_void;
+
+  *p_data->v_i = i + 1;
+
+  SEXP x_i = (p_data->x_object) ?
+    Rf_eval(call_dot_x_subset2_i, p_data->env) :
+    p_vec_get(p_data->v_x, p_data->x_type, i);
+  Rf_defineVar(sym_dot_x_i, x_i, p_data->env);
+
+  return R_forceAndCall(call_map, force_map, p_data->env);
 }
 
-SEXP map2_impl(SEXP env,
-               SEXP ffi_type,
-               SEXP progress,
-               SEXP ffi_n,
-               SEXP names,
-               SEXP i) {
-  static SEXP call = NULL;
-  if (call == NULL) {
-    SEXP x_sym = Rf_install(".x");
-    SEXP y_sym = Rf_install(".y");
-    SEXP f_sym = Rf_install(".f");
-    SEXP i_sym = Rf_install("i");
+static inline SEXP map2_exec(const void* p_data_void, int i) {
+  const struct map2_exec_data* p_data = (const struct map2_exec_data*) p_data_void;
 
-    // Constructs a call like f(x[[i]], y[[i]], ...)
-    SEXP x_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, x_sym, i_sym));
-    SEXP y_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, y_sym, i_sym));
+  *p_data->v_i = i + 1;
 
-    call = Rf_lang4(f_sym, x_i_sym, y_i_sym, R_DotsSymbol);
-    R_PreserveObject(call);
+  SEXP x_i = (p_data->x_object) ?
+    Rf_eval(call_dot_x_subset2_i, p_data->env) :
+    p_vec_get(p_data->v_x, p_data->x_type, i);
+  Rf_defineVar(sym_dot_x_i, x_i, p_data->env);
 
-    UNPROTECT(2);
-  }
+  SEXP y_i = (p_data->y_object) ?
+    Rf_eval(call_dot_y_subset2_i, p_data->env) :
+    p_vec_get(p_data->v_y, p_data->y_type, i);
+  Rf_defineVar(sym_dot_y_i, y_i, p_data->env);
 
-  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
-  int n = INTEGER_ELT(ffi_n, 0);
-  int* p_i = INTEGER(i);
-  int force = 2;
-
-  return call_loop(
-    env,
-    call,
-    type,
-    progress,
-    n,
-    names,
-    p_i,
-    force
-  );
+  return R_forceAndCall(call_map2, force_map2, p_data->env);
 }
 
-SEXP pmap_impl(SEXP env,
-               SEXP ffi_type,
-               SEXP progress,
-               SEXP ffi_n,
-               SEXP names,
-               SEXP i,
-               SEXP call_names,
-               SEXP ffi_call_n) {
-  // Construct call like f(.l[[1]][[i]], .l[[2]][[i]], ...)
-  //
-  // Currently accessing S3 vectors in a list like .l[[c(1, i)]] will not
-  // preserve the class (cf. #358).
+static inline SEXP pmap_exec(const void* p_data_void, int i) {
+  const struct pmap_exec_data* p_data = (const struct pmap_exec_data*) p_data_void;
+
+  *p_data->v_i = i + 1;
+
+  for (int j = 0; j < p_data->n_l; ++j) {
+    const struct pmap_elt* p_elt = &p_data->v_l[j];
+
+    SEXP elt_i = (p_elt->elt_object) ?
+      Rf_eval(p_elt->call_elt_subset2_i, p_data->env) :
+      p_vec_get(p_elt->v_elt, p_elt->elt_type, i);
+    Rf_defineVar(p_elt->sym_elt_i, elt_i, p_data->env);
+  }
+
+  return R_forceAndCall(p_data->call_pmap, p_data->force_pmap, p_data->env);
+}
+
+SEXP map_impl(
+  SEXP x,
+  SEXP env,
+  SEXP ffi_type,
+  SEXP progress,
+  SEXP ffi_n,
+  SEXP names,
+  SEXP i
+) {
+  const SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  const int n = INTEGER_ELT(ffi_n, 0);
+  int* v_i = INTEGER(i);
+
+  const bool x_object = Rf_isObject(x);
+  const SEXPTYPE x_type = TYPEOF(x);
+  const void* v_x = x_object ? NULL : vec_cbegin(x, x_type);
+
+  const struct map_exec_data data = (struct map_exec_data) {
+    .x = x,
+    .v_x = v_x,
+    .x_type = x_type,
+    .x_object = x_object,
+    .v_i = v_i,
+    .env = env
+  };
+
+  *v_i = 0;
+  SEXP out = call_loop(&data, map_exec, type, progress, n, names);
+  *v_i = 0;
+
+  return out;
+}
+
+SEXP map2_impl(
+  SEXP x,
+  SEXP y,
+  SEXP env,
+  SEXP ffi_type,
+  SEXP progress,
+  SEXP ffi_n,
+  SEXP names,
+  SEXP i
+) {
+  const SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  const int n = INTEGER_ELT(ffi_n, 0);
+  int* v_i = INTEGER(i);
+
+  const bool x_object = Rf_isObject(x);
+  const SEXPTYPE x_type = TYPEOF(x);
+  const void* v_x = x_object ? NULL : vec_cbegin(x, x_type);
+
+  const bool y_object = Rf_isObject(y);
+  const SEXPTYPE y_type = TYPEOF(y);
+  const void* v_y = y_object ? NULL : vec_cbegin(y, y_type);
+
+  const struct map2_exec_data data = (struct map2_exec_data) {
+    .x = x,
+    .v_x = v_x,
+    .x_type = x_type,
+    .x_object = x_object,
+    .y = y,
+    .v_y = v_y,
+    .y_type = y_type,
+    .y_object = y_object,
+    .v_i = v_i,
+    .env = env
+  };
+
+  *v_i = 0;
+  SEXP out = call_loop(&data, map2_exec, type, progress, n, names);
+  *v_i = 0;
+
+  return out;
+}
+
+SEXP pmap_impl(
+  SEXP l,
+  SEXP env,
+  SEXP ffi_type,
+  SEXP progress,
+  SEXP ffi_n,
+  SEXP names,
+  SEXP i
+) {
+  int n_prot = 0;
+
+  const SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  const int n = INTEGER_ELT(ffi_n, 0);
+  int* v_i = INTEGER(i);
+
+  char buf[32];
+
+  const int n_l = (int) Rf_xlength(l);
+  struct pmap_elt* v_l = (struct pmap_elt*) R_alloc(n_l, sizeof(struct pmap_elt));
+
+  // Build `pmap_elt`s!
+  for (int j = 0; j < n_l; ++j) {
+    // `l` is guaranteed to be a bare list at this point by `pmap()`
+    SEXP elt = VECTOR_ELT(l, j);
+
+    const bool elt_object = Rf_isObject(elt);
+    const SEXPTYPE elt_type = TYPEOF(elt);
+    const void* v_elt = elt_object ? NULL : vec_cbegin(elt, elt_type);
+
+    v_l[j].elt = elt;
+    v_l[j].v_elt = v_elt;
+    v_l[j].elt_type = elt_type;
+    v_l[j].elt_object = elt_object;
+
+    // `.l_{elt}_i`
+    snprintf(buf, sizeof(buf), ".l_%d_i", j + 1);
+    v_l[j].sym_elt_i = Rf_install(buf);
+
+    // `.l_{elt}[[i]]`, with `elt` installed as `.l_{elt}` in `env`.
+    // Only used when `elt_object` is true, but we always set it up for simplicity.
+    snprintf(buf, sizeof(buf), ".l_%d", j + 1);
+    SEXP sym_elt = Rf_install(buf);
+    Rf_defineVar(sym_elt, elt, env);
+    v_l[j].call_elt_subset2_i = PROTECT_N(Rf_lang3(R_Bracket2Symbol, sym_elt, sym_i), &n_prot);
+  }
+
+  // Construct call like `f(.l_1_i, .l_2_i, ...l_{elt}_i, ...)`
   //
   // We construct the call backwards because can only add to the front of a
   // linked list. That makes PROTECTion tricky because we need to update it
   // each time to point to the start of the linked list.
-  SEXP l_sym = Rf_install(".l");
-  SEXP f_sym = Rf_install(".f");
-  SEXP i_sym = Rf_install("i");
+  SEXP call_pmap = Rf_lang1(R_DotsSymbol);
+  PROTECT_INDEX call_pmap_pi;
+  PROTECT_WITH_INDEX(call_pmap, &call_pmap_pi);
+  ++n_prot;
 
-  SEXP call = Rf_lang1(R_DotsSymbol);
-  PROTECT_INDEX call_shelter;
-  PROTECT_WITH_INDEX(call, &call_shelter);
-
-  bool has_call_names = call_names != R_NilValue;
+  SEXP call_names = PROTECT_N(Rf_getAttrib(l, R_NamesSymbol), &n_prot);
+  const bool has_call_names = call_names != R_NilValue;
   const SEXP* v_call_names = has_call_names ? STRING_PTR_RO(call_names) : NULL;
-  int call_n = INTEGER_ELT(ffi_call_n, 0);
 
-  for (int j = call_n - 1; j >= 0; --j) {
-    // Construct call like .l[[j]][[i]]
-    SEXP j_val = PROTECT(Rf_ScalarInteger(j + 1));
-    SEXP l_j_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, l_sym, j_val));
-    SEXP l_j_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, l_j_sym, i_sym));
-
-    call = Rf_lcons(l_j_i_sym, call);
-    REPROTECT(call, call_shelter);
+  for (int j = n_l - 1; j >= 0; --j) {
+    call_pmap = Rf_lcons(v_l[j].sym_elt_i, call_pmap);
+    REPROTECT(call_pmap, call_pmap_pi);
 
     if (has_call_names) {
       const char* call_name = CHAR(v_call_names[j]);
 
       if (call_name[0] != '\0') {
-        SET_TAG(call, Rf_install(call_name));
+        SET_TAG(call_pmap, Rf_install(call_name));
       }
     }
-
-    UNPROTECT(3);
   }
 
-  call = Rf_lcons(f_sym, call);
-  REPROTECT(call, call_shelter);
+  call_pmap = Rf_lcons(sym_dot_f, call_pmap);
+  REPROTECT(call_pmap, call_pmap_pi);
 
-  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
-  int n = INTEGER_ELT(ffi_n, 0);
-  int* p_i = INTEGER(i);
-  int force = call_n;
+  const struct pmap_exec_data data = (struct pmap_exec_data) {
+    .v_l = v_l,
+    .n_l = n_l,
+    .call_pmap = call_pmap,
+    .force_pmap = n_l,
+    .v_i = v_i,
+    .env = env
+  };
 
-  SEXP out = call_loop(
-    env,
-    call,
-    type,
-    progress,
-    n,
-    names,
-    p_i,
-    force
-  );
+  *v_i = 0;
+  SEXP out = call_loop(&data, pmap_exec, type, progress, n, names);
+  *v_i = 0;
 
-  UNPROTECT(1);
+  UNPROTECT(n_prot);
   return out;
+}
+
+void map_init(void) {
+  sym_i = Rf_install("i");
+  sym_dot_f = Rf_install(".f");
+  sym_dot_x = Rf_install(".x");
+  sym_dot_y = Rf_install(".y");
+  sym_dot_x_i = Rf_install(".x_i");
+  sym_dot_y_i = Rf_install(".y_i");
+
+  // `.x[[i]]`
+  call_dot_x_subset2_i = Rf_lang3(R_Bracket2Symbol, sym_dot_x, sym_i);
+  R_PreserveObject(call_dot_x_subset2_i);
+
+  // `.y[[i]]`
+  call_dot_y_subset2_i = Rf_lang3(R_Bracket2Symbol, sym_dot_y, sym_i);
+  R_PreserveObject(call_dot_y_subset2_i);
+
+  // `.f(.x_i, ...)`
+  call_map = Rf_lang3(sym_dot_f, sym_dot_x_i, R_DotsSymbol);
+  R_PreserveObject(call_map);
+
+  // `.f(.x_i, .y_i, ...)`
+  call_map2 = Rf_lang4(sym_dot_f, sym_dot_x_i, sym_dot_y_i, R_DotsSymbol);
+  R_PreserveObject(call_map2);
 }

--- a/src/map.h
+++ b/src/map.h
@@ -2,21 +2,25 @@
 #define MAP_H
 
 extern "C" {
-  SEXP map_impl(SEXP env,
-                SEXP ffi_type,
-                SEXP progress,
-                SEXP ffi_n,
-                SEXP names,
-                SEXP i);
+  SEXP map_impl(
+    SEXP x,
+    SEXP env,
+    SEXP ffi_type,
+    SEXP progress,
+    SEXP ffi_n,
+    SEXP names,
+    SEXP i
+  );
 
-  SEXP pmap_impl(SEXP env,
-                 SEXP ffi_type,
-                 SEXP progress,
-                 SEXP ffi_n,
-                 SEXP names,
-                 SEXP i,
-                 SEXP call_names,
-                 SEXP ffi_call_n);
+  SEXP pmap_impl(
+    SEXP l,
+    SEXP env,
+    SEXP ffi_type,
+    SEXP progress,
+    SEXP ffi_n,
+    SEXP names,
+    SEXP i
+  );
 }
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,12 @@
  SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits);
 #endif
 
+#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
+static inline const SEXP* VECTOR_PTR_RO(SEXP x) {
+  return (const SEXP*) DATAPTR_RO(x);
+}
+#endif
+
 SEXP sym_protect(SEXP x);
 
 bool is_vector(SEXP x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <Rversion.h>
 
+#define PROTECT_N(x, n) (++(*n), PROTECT(x))
 
 #if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
  SEXP R_getVarEx(SEXP symbol, SEXP rho, Rboolean inherits, SEXP ifnotfound);
@@ -17,5 +18,30 @@ bool is_vector(SEXP x);
 SEXP lang7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y);
 SEXP lang8(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y, SEXP z);
 
+static inline const void* vec_cbegin(SEXP x, SEXPTYPE type) {
+  switch (type) {
+    case LGLSXP: return LOGICAL_RO(x);
+    case INTSXP: return INTEGER_RO(x);
+    case REALSXP: return REAL_RO(x);
+    case CPLXSXP: return COMPLEX_RO(x);
+    case RAWSXP: return RAW_RO(x);
+    case STRSXP: return STRING_PTR_RO(x);
+    case VECSXP: return VECTOR_PTR_RO(x);
+    default: Rf_error("Unreachable");
+  }
+}
+
+static inline SEXP p_vec_get(const void* v_x, SEXPTYPE type, int i) {
+  switch (type) {
+    case LGLSXP: return Rf_ScalarLogical(((const int*) v_x)[i]);
+    case INTSXP: return Rf_ScalarInteger(((const int*) v_x)[i]);
+    case REALSXP: return Rf_ScalarReal(((const double*) v_x)[i]);
+    case CPLXSXP: return Rf_ScalarComplex(((const Rcomplex*) v_x)[i]);
+    case RAWSXP: return Rf_ScalarRaw(((const Rbyte*) v_x)[i]);
+    case STRSXP: return Rf_ScalarString(((const SEXP*) v_x)[i]);
+    case VECSXP: return ((const SEXP*) v_x)[i];
+    default: Rf_error("Unreachable");
+  }
+}
 
 #endif

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -5,7 +5,7 @@ test_that("preserves names", {
 
 test_that("creates simple call", {
   out <- map(1, function(x) sys.call())[[1]]
-  expect_equal(out, quote(.f(.x[[i]], ...)))
+  expect_equal(out, quote(.f(.x_i, ...)))
 })
 
 test_that("fails on non-vectors", {
@@ -90,8 +90,16 @@ test_that("logical and integer NA become correct double NA", {
 })
 
 test_that("map forces arguments in same way as base R", {
+  x <- 1:2
   f_map <- map(1:2, function(i) function(x) x + i)
   f_base <- lapply(1:2, function(i) function(x) x + i)
+
+  expect_equal(f_map[[1]](0), f_base[[1]](0))
+  expect_equal(f_map[[2]](0), f_base[[2]](0))
+
+  x <- structure(1:2, class = "foo")
+  f_map <- map(x, function(i) function(x) x + i)
+  f_base <- lapply(x, function(i) function(x) x + i)
 
   expect_equal(f_map[[1]](0), f_base[[1]](0))
   expect_equal(f_map[[2]](0), f_base[[2]](0))


### PR DESCRIPTION
Closes https://github.com/tidyverse/purrr/pull/1255 with an alternative design, but a similar approach

@ErdaradunGaztea had some really nice ideas outlined in #1255. Using C level accessors for unclassed objects in `map()` is also something I've been wanting to work on for awhile, so that was a nice jumping off point that proved out the concept. I've taken that PR to its extreme, rewriting to match our style a bit more, and also extending support to `pmap()`.

# Overview!

This PR rewrites the guts of `map()`, `map2()`, and `pmap()` (and thus, the whole family really).

The core change was to recognize that we were adding quite a bit of overhead by accessing elements with `[[` like this:

```r
# map()
.f(.x[[i]], ...)

# map2()
.f(.x[[i]], .y[[i]], ...)

# pmap()
.f(.l[[1]][[i]], .l[[2]][[i]], .l[[3]][[i]], ...)
```

For unclassed objects, extracting with `[[` adds a rather large amount of overhead! Particularly with large lists if your `.f` is extremely fast, like with `names()` or `is.null()`. Also, for `pmap()` in particular it's pretty wasteful to do `.l[[1]]` at each iteration! We actually know `.l` is a bare list at that point, so we can extract that once up front.

Instead, we can do this with unclassed objects (enjoy my pseudo C / R code):

```r
v_x <- VECTOR_PTR_RO(x) # done once up front
.x_i <- v_x[i] # at each iteration, fast C access and Rf_defineVar to bind to `.x_i`
.f(.x_i, ...) # now call this instead

v_x <- VECTOR_PTR_RO(x)
v_y <- VECTOR_PTR_RO(y)
.x_i <- v_x[i]
.y_i <- v_y[i]
.f(.x_i, .y_i, ...)

v_l <- VECTOR_PTR_RO(l)
v_l_1 <- VECTOR_PTR_RO(v_l[1])
v_l_2 <- VECTOR_PTR_RO(v_l[2])
v_l_3 <- VECTOR_PTR_RO(v_l[3]) # all this is done up front!
.l_1_i <- v_l_1[i]
.l_2_i <- v_l_2[i]
.l_3_i <- v_l_3[i]
.f(l_1_i, l_2_i, .l_3_i, ...)
```

And with classed objects, we still make the `.x_i` binding, we just do it via `[[` like before.

For unclassed objects, this does significantly reduce the amount of overhead that purrr itself is adding on top of user function execution (see benchmarks).

The challenge of this PR was doing this in a clean way, but I think I've managed something that feels pretty good, symmetrical, and maintainable across all of map/map2/pmap.

# Breaking change-ish

Technically the call we create for `.f` is different now, i.e.

``` r
library(purrr)
map(1, function(x) sys.call())
#> [[1]]
#> .f(.x[[i]], ...)
map(1, function(x) substitute(x))
#> [[1]]
#> .x[[i]]
```

After:

``` r
library(purrr)
map(1, function(x) sys.call())
#> [[1]]
#> .f(.x_i, ...)
map(1, function(x) substitute(x))
#> [[1]]
#> .x_i
```

I would hope that no one is actually relying on this (beyond a single one of our own tests). And if someone accidentally was, then I think I would be happy to send them a PR to fix this, because this feels like "purrr internals" territory.

Note that this call does _not_ show up in a standard error report:

``` r
purrr::map(1, function(x) x + "i")
#> Error in `purrr::map()`:
#> ℹ In index: 1.
#> Caused by error in `x + "i"`:
#> ! non-numeric argument to binary operator
```

It does show up in the traceback (both rlang's and `traceback()`) but it is in there pretty deep in "internals" territory IMO, so this doesn't bother me, and I still think it is reasonably informative:

<img width="517" height="318" alt="Screenshot 2026-07-01 at 5 03 15 PM" src="https://github.com/user-attachments/assets/18763fff-874f-445a-8b1f-2eebc9d2c312" />


# Benchmarks!

A handful of benchmarks are listed below. Somewhat arbitrary, but I do think patterns like `map(x, names)` and `map_lgl(x, is.null)` in particular are pretty common, and since `.f` is a primitive that is already extremely fast, a large part of the overhead here was actually us and the way we accessed elements of `.x`.

Also, not shown here, but you can treat "old purrr" as roughly equivalent to base `lapply()` and friends. So we have gotten faster than `lapply()` with many common cases, which is cool!

```r
# map

# Pluck names off each list element
# - Large unclassed list (uses `VECTOR_PTR_RO`)
# - map()
# - primitive names()
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    x <- as.list(1:1e6 + 0L)
    bench::mark(map(x, names), iterations = 50)
  }
)
#> # A tibble: 2 × 7
#>   pkg                    expression     min  median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                  <bch:expr> <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@fe… map(x, na…  59.3ms  60.8ms     16.2     7.82MB     22.4
#> 2 purrr                  map(x, na… 129.4ms 136.6ms      7.00    7.82MB     11.8

# Slightly slower when we have classed objects, but typically a custom `[[`
# method is going to dominate the computation anyways
# - Large classed list (we use `[[`)
# - map()
# - primitive names()
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    x <- structure(as.list(1:1e6 + 0L), class = c("foo", "list"))
    bench::mark(map(x, names), iterations = 50)
  }
)
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@featu… map(x, na… 563ms  583ms      1.68    7.82MB     10.4
#> 2 purrr                     map(x, na… 539ms  557ms      1.77    7.82MB     10.9

# - Many columned data.frame (special case, we unclass this internally already
#   in vctrs_vec_compat so we end up using fast VECTOR_PTR_RO)
# - map_chr
# - primitive typeof
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    names <- as.character(1:1e5)
    x <- vctrs::new_data_frame(rlang::set_names(as.list(1:1e5 + 0L), names))
    bench::mark(map_chr(x, typeof), iterations = 50)
  }
)
#> # A tibble: 2 × 7
#>   pkg                      expression    min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                    <bch:expr> <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@feat… map_chr(x… 17.8ms 18.7ms      50.9     945KB    181. 
#> 2 purrr                    map_chr(x… 26.5ms 27.5ms      35.8     945KB     36.5

# Detect `NULL`s
# - Large unclassed list
# - map_lgl()
# - primitive is.null()
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    set.seed(123)
    x <- sample(list(NULL, 1), 1e6, replace = TRUE)
    bench::mark(map_lgl(x, is.null), iterations = 50)
  }
)
#> # A tibble: 2 × 7
#>   pkg                    expression     min  median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                  <bch:expr> <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@fe… map_lgl(x…  65.4ms  68.9ms     14.2        4MB     66.0
#> 2 purrr                  map_lgl(x… 134.7ms 142.3ms      6.92       4MB     52.3

# Just showing iteration over an atomic
# - Large unclassed atomic (use `INTEGER_RO`, etc)
# - map_int()
# - non-primitive identity(), so slower in general
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    x <- 1:1e6 + 0L
    bench::mark(map_int(x, identity), iterations = 50)
  }
)
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@featu… map_int(x… 167ms  176ms      5.62    3.97MB     59.2
#> 2 purrr                     map_int(x… 234ms  247ms      4.02    3.97MB     54.2
```

```r
# map2

# Set an attribute on each element
# - Large unclassed list
# - Large unclassed integer
# - map2()
# - primitive `attr<-`()
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    set.seed(123)
    x <- as.list(1:1e6 + 0L)
    y <- sample(letters, 1e6, replace = TRUE)
    bench::mark(
      map2(x, y, `attr<-`, which = "y"),
      iterations = 50
    )
  }
)
#> # A tibble: 2 × 7
#>   pkg                      expression   min  median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                    <bch:expr> <bch> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@feat… "map2(x, … 484ms 752.6ms     1.23     7.79MB     3.62
#> 2 purrr                    "map2(x, … 488ms   1.15s     0.889    7.78MB     4.27

# Two classed atomics (So these access with `[[`, and use a real custom method,
# which dominates the time here)
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    set.seed(123)
    x <- .Date(sample(1:10, 1e6, replace = TRUE))
    y <- .Date(sample(1:10, 1e6, replace = TRUE))
    bench::mark(map2(x, y, list), iterations = 5)
  }
)
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@featu… map2(x, y… 5.32s  5.37s     0.180    38.3MB     4.46
#> 2 purrr                     map2(x, y… 5.26s  5.41s     0.181    38.3MB     4.48
```


```r
# pmap

# Poor man's transpose-ish operation
# - Large unclassed atomics
# - pmap()
# - primitive list
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    set.seed(123)
    x <- sample(1:10, 1e6, replace = TRUE)
    y <- sample(letters, 1e6, replace = TRUE)
    z <- sample(c(TRUE, FALSE), 1e6, replace = TRUE)
    bench::mark(pmap(list(x, y, z), list), iterations = 50)
  }
)
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@featu… pmap(list… 337ms  407ms      2.52    7.87MB     6.99
#> 2 purrr                     pmap(list… 646ms  855ms      1.20    7.87MB     5.53

# - All classed lists (so these all use `[[` to access elements)
# - pmap()
# - primitive c
cross::bench_versions(
  pkgs = c("DavisVaughan/purrr@feature/faster-map", "purrr"),
  {
    library(purrr)
    set.seed(123)
    x <- structure(
      as.list(sample(1:10, 1e6, replace = TRUE)),
      class = c("foo", "list")
    )
    y <- structure(
      as.list(sample(letters, 1e6, replace = TRUE)),
      class = c("bar", "list")
    )
    z <- structure(
      as.list(sample(c(TRUE, FALSE), 1e6, replace = TRUE)),
      class = c("baz", "list")
    )
    bench::mark(pmap(list(x, y, z), c), iterations = 50)
  }
)
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 DavisVaughan/purrr@featu… pmap(list… 2.37s  2.47s     0.406    7.87MB     7.52
#> 2 purrr                     pmap(list…  2.5s  2.58s     0.388    7.87MB     9.55
```