### PR TITLE
Speed up the map family

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* All `map()` functions now have less overhead, particularly on unclassed vectors. This means that they should run faster when `.f` itself is very fast, like with the common cases of `map(x, names)` or `map_lgl(x, is.null)` (#1263, with an assist from @ErdaradunGaztea).
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/R/map.R
+++ b/R/map.R
@@ -221,7 +221,16 @@ map_ <- function(
     i = i,
     names = names,
     error_call = .purrr_error_call,
-    call_with_cleanup(map_impl, environment(), .type, .progress, n, names, i)
+    call_with_cleanup(
+      map_impl,
+      .x,
+      environment(),
+      .type,
+      .progress,
+      n,
+      names,
+      i
+    )
   )
 }
 

--- a/R/map2.R
+++ b/R/map2.R
@@ -105,7 +105,17 @@ map2_ <- function(
     i = i,
     names = names,
     error_call = .purrr_error_call,
-    call_with_cleanup(map2_impl, environment(), .type, .progress, n, names, i)
+    call_with_cleanup(
+      map2_impl,
+      .x,
+      .y,
+      environment(),
+      .type,
+      .progress,
+      n,
+      names,
+      i
+    )
   )
 }
 

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -165,9 +165,6 @@ pmap_ <- function(
     return(mmap_(.l, .f, .progress, .type, .purrr_error_call, ...))
   }
 
-  call_names <- names(.l)
-  call_n <- length(.l)
-
   i <- 0L
   with_indexed_errors(
     i = i,
@@ -175,14 +172,13 @@ pmap_ <- function(
     error_call = .purrr_error_call,
     call_with_cleanup(
       pmap_impl,
+      .l,
       environment(),
       .type,
       .progress,
       n,
       names,
-      i,
-      call_names,
-      call_n
+      i
     )
   )
 }

--- a/src/init.c
+++ b/src/init.c
@@ -10,6 +10,7 @@
 #include "cleancall.h"
 
 extern void unbound_init(void);
+extern void map_init(void);
 
 /* .Call calls */
 extern SEXP coerce_impl(SEXP, SEXP);
@@ -18,9 +19,9 @@ extern SEXP flatten_impl(SEXP);
 extern SEXP every_impl(SEXP, SEXP, SEXP);
 extern SEXP some_impl(SEXP, SEXP, SEXP);
 extern SEXP none_impl(SEXP, SEXP, SEXP);
-extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP transpose_impl(SEXP, SEXP);
 extern SEXP vflatten_impl(SEXP, SEXP);
 
@@ -32,9 +33,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"every_impl",            (DL_FUNC) &every_impl,     3},
   {"some_impl",             (DL_FUNC) &some_impl,      3},
   {"none_impl",             (DL_FUNC) &none_impl,      3},
-  {"map_impl",              (DL_FUNC) &map_impl,       6},
-  {"map2_impl",             (DL_FUNC) &map2_impl,      6},
-  {"pmap_impl",             (DL_FUNC) &pmap_impl,      8},
+  {"map_impl",              (DL_FUNC) &map_impl,       7},
+  {"map2_impl",             (DL_FUNC) &map2_impl,      8},
+  {"pmap_impl",             (DL_FUNC) &pmap_impl,      7},
   {"transpose_impl",        (DL_FUNC) &transpose_impl, 2},
   {"vflatten_impl",         (DL_FUNC) &vflatten_impl,  2},
   {"purrr_eval",            (DL_FUNC) &Rf_eval,        2},
@@ -47,4 +48,5 @@ export void R_init_purrr(DllInfo *dll)
     R_useDynamicSymbols(dll, FALSE);
     cleancall_init();
     unbound_init();
+    map_init();
 }

--- a/src/map.c
+++ b/src/map.c
@@ -3,7 +3,6 @@
 #include <Rversion.h>
 #include <Rinternals.h>
 #include "coerce.h"
-#include "conditions.h"
 #include "utils.h"
 
 // Including <cli/progress.h> before "cleancall.h" because we want to register
@@ -11,22 +10,36 @@
 #include <cli/progress.h>
 #include "cleancall.h"
 
-static
-void cb_progress_done(void* bar_ptr) {
+static SEXP sym_i = NULL;
+static SEXP sym_dot_f = NULL;
+static SEXP sym_dot_x = NULL;
+static SEXP sym_dot_y = NULL;
+static SEXP sym_dot_x_i = NULL;
+static SEXP sym_dot_y_i = NULL;
+
+static SEXP call_dot_x_subset2_i = NULL;
+static SEXP call_dot_y_subset2_i = NULL;
+
+static SEXP call_map = NULL;
+static SEXP call_map2 = NULL;
+
+static int force_map = 1;
+static int force_map2 = 2;
+
+static void cb_progress_done(void* bar_ptr) {
   SEXP bar = (SEXP)bar_ptr;
   cli_progress_done(bar);
   R_ReleaseObject(bar);
 }
 
-// call must involve i
-SEXP call_loop(SEXP env,
-               SEXP call,
-               SEXPTYPE type,
-               SEXP progress,
-               int n,
-               SEXP names,
-               int* p_i,
-               int force) {
+static inline SEXP call_loop(
+  const void* p_data,
+  SEXP (*fn_exec)(const void* p_data, int i),
+  SEXPTYPE type,
+  SEXP progress,
+  int n,
+  SEXP names
+) {
   SEXP bar = cli_progress_bar(n, progress);
   R_PreserveObject(bar);
   r_call_on_exit((void (*)(void*)) cb_progress_done, (void*) bar);
@@ -35,8 +48,6 @@ SEXP call_loop(SEXP env,
   Rf_setAttrib(out, R_NamesSymbol, names);
 
   for (int i = 0; i < n; ++i) {
-    *p_i = i + 1;
-
     if (CLI_SHOULD_TICK) {
       cli_progress_set(bar, i);
     }
@@ -44,7 +55,7 @@ SEXP call_loop(SEXP env,
       R_CheckUserInterrupt();
     }
 
-    SEXP res = PROTECT(R_forceAndCall(call, force, env));
+    SEXP res = PROTECT(fn_exec(p_data, i));
 
     if (type != VECSXP && Rf_length(res) != 1) {
       Rf_errorcall(R_NilValue, "Result must be length 1, not %i.", Rf_length(res));
@@ -54,159 +65,296 @@ SEXP call_loop(SEXP env,
     UNPROTECT(1);
   }
 
-  *p_i = 0;
-
   UNPROTECT(1);
   return out;
 }
 
-SEXP map_impl(SEXP env,
-              SEXP ffi_type,
-              SEXP progress,
-              SEXP ffi_n,
-              SEXP names,
-              SEXP i) {
-  static SEXP call = NULL;
-  if (call == NULL) {
-    SEXP x_sym = Rf_install(".x");
-    SEXP f_sym = Rf_install(".f");
-    SEXP i_sym = Rf_install("i");
+struct map_exec_data {
+  SEXP x;
+  const void* v_x;
+  SEXPTYPE x_type;
+  bool x_object;
 
-    // Constructs a call like f(x[[i]], ...) - don't want to substitute
-    // actual values for f or x, because they may be long, which creates
-    // bad tracebacks()
-    SEXP x_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, x_sym, i_sym));
+  int* v_i;
+  SEXP env;
+};
 
-    call = Rf_lang3(f_sym, x_i_sym, R_DotsSymbol);
-    R_PreserveObject(call);
+struct map2_exec_data {
+  SEXP x;
+  const void* v_x;
+  SEXPTYPE x_type;
+  bool x_object;
 
-    UNPROTECT(1);
-  }
+  SEXP y;
+  const void* v_y;
+  SEXPTYPE y_type;
+  bool y_object;
 
-  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
-  int n = INTEGER_ELT(ffi_n, 0);
-  int* p_i = INTEGER(i);
-  int force = 1;
+  int* v_i;
+  SEXP env;
+};
 
-  return call_loop(
-    env,
-    call,
-    type,
-    progress,
-    n,
-    names,
-    p_i,
-    force
-  );
+struct pmap_elt {
+  SEXP elt;
+  const void* v_elt;
+  SEXPTYPE elt_type;
+  bool elt_object;
+
+  // .l_{elt}_i
+  SEXP sym_elt_i;
+  // .l_{elt}[[i]]
+  SEXP call_elt_subset2_i;
+};
+
+struct pmap_exec_data {
+  const struct pmap_elt* v_l;
+  int n_l;
+
+  // .f(.l_1_i, .l_2_i, .l_3_i, ...)
+  SEXP call_pmap;
+  int force_pmap;
+
+  int* v_i;
+  SEXP env;
+};
+
+static inline SEXP map_exec(const void* p_data_void, int i) {
+  const struct map_exec_data* p_data = (const struct map_exec_data*) p_data_void;
+
+  *p_data->v_i = i + 1;
+
+  SEXP x_i = (p_data->x_object) ?
+    Rf_eval(call_dot_x_subset2_i, p_data->env) :
+    p_vec_get(p_data->v_x, p_data->x_type, i);
+  Rf_defineVar(sym_dot_x_i, x_i, p_data->env);
+
+  return R_forceAndCall(call_map, force_map, p_data->env);
 }
 
-SEXP map2_impl(SEXP env,
-               SEXP ffi_type,
-               SEXP progress,
-               SEXP ffi_n,
-               SEXP names,
-               SEXP i) {
-  static SEXP call = NULL;
-  if (call == NULL) {
-    SEXP x_sym = Rf_install(".x");
-    SEXP y_sym = Rf_install(".y");
-    SEXP f_sym = Rf_install(".f");
-    SEXP i_sym = Rf_install("i");
+static inline SEXP map2_exec(const void* p_data_void, int i) {
+  const struct map2_exec_data* p_data = (const struct map2_exec_data*) p_data_void;
 
-    // Constructs a call like f(x[[i]], y[[i]], ...)
-    SEXP x_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, x_sym, i_sym));
-    SEXP y_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, y_sym, i_sym));
+  *p_data->v_i = i + 1;
 
-    call = Rf_lang4(f_sym, x_i_sym, y_i_sym, R_DotsSymbol);
-    R_PreserveObject(call);
+  SEXP x_i = (p_data->x_object) ?
+    Rf_eval(call_dot_x_subset2_i, p_data->env) :
+    p_vec_get(p_data->v_x, p_data->x_type, i);
+  Rf_defineVar(sym_dot_x_i, x_i, p_data->env);
 
-    UNPROTECT(2);
-  }
+  SEXP y_i = (p_data->y_object) ?
+    Rf_eval(call_dot_y_subset2_i, p_data->env) :
+    p_vec_get(p_data->v_y, p_data->y_type, i);
+  Rf_defineVar(sym_dot_y_i, y_i, p_data->env);
 
-  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
-  int n = INTEGER_ELT(ffi_n, 0);
-  int* p_i = INTEGER(i);
-  int force = 2;
-
-  return call_loop(
-    env,
-    call,
-    type,
-    progress,
-    n,
-    names,
-    p_i,
-    force
-  );
+  return R_forceAndCall(call_map2, force_map2, p_data->env);
 }
 
-SEXP pmap_impl(SEXP env,
-               SEXP ffi_type,
-               SEXP progress,
-               SEXP ffi_n,
-               SEXP names,
-               SEXP i,
-               SEXP call_names,
-               SEXP ffi_call_n) {
-  // Construct call like f(.l[[1]][[i]], .l[[2]][[i]], ...)
-  //
-  // Currently accessing S3 vectors in a list like .l[[c(1, i)]] will not
-  // preserve the class (cf. #358).
+static inline SEXP pmap_exec(const void* p_data_void, int i) {
+  const struct pmap_exec_data* p_data = (const struct pmap_exec_data*) p_data_void;
+
+  *p_data->v_i = i + 1;
+
+  for (int j = 0; j < p_data->n_l; ++j) {
+    const struct pmap_elt* p_elt = &p_data->v_l[j];
+
+    SEXP elt_i = (p_elt->elt_object) ?
+      Rf_eval(p_elt->call_elt_subset2_i, p_data->env) :
+      p_vec_get(p_elt->v_elt, p_elt->elt_type, i);
+    Rf_defineVar(p_elt->sym_elt_i, elt_i, p_data->env);
+  }
+
+  return R_forceAndCall(p_data->call_pmap, p_data->force_pmap, p_data->env);
+}
+
+SEXP map_impl(
+  SEXP x,
+  SEXP env,
+  SEXP ffi_type,
+  SEXP progress,
+  SEXP ffi_n,
+  SEXP names,
+  SEXP i
+) {
+  const SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  const int n = INTEGER_ELT(ffi_n, 0);
+  int* v_i = INTEGER(i);
+
+  const bool x_object = Rf_isObject(x);
+  const SEXPTYPE x_type = TYPEOF(x);
+  const void* v_x = x_object ? NULL : vec_cbegin(x, x_type);
+
+  const struct map_exec_data data = (struct map_exec_data) {
+    .x = x,
+    .v_x = v_x,
+    .x_type = x_type,
+    .x_object = x_object,
+    .v_i = v_i,
+    .env = env
+  };
+
+  *v_i = 0;
+  SEXP out = call_loop(&data, map_exec, type, progress, n, names);
+  *v_i = 0;
+
+  return out;
+}
+
+SEXP map2_impl(
+  SEXP x,
+  SEXP y,
+  SEXP env,
+  SEXP ffi_type,
+  SEXP progress,
+  SEXP ffi_n,
+  SEXP names,
+  SEXP i
+) {
+  const SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  const int n = INTEGER_ELT(ffi_n, 0);
+  int* v_i = INTEGER(i);
+
+  const bool x_object = Rf_isObject(x);
+  const SEXPTYPE x_type = TYPEOF(x);
+  const void* v_x = x_object ? NULL : vec_cbegin(x, x_type);
+
+  const bool y_object = Rf_isObject(y);
+  const SEXPTYPE y_type = TYPEOF(y);
+  const void* v_y = y_object ? NULL : vec_cbegin(y, y_type);
+
+  const struct map2_exec_data data = (struct map2_exec_data) {
+    .x = x,
+    .v_x = v_x,
+    .x_type = x_type,
+    .x_object = x_object,
+    .y = y,
+    .v_y = v_y,
+    .y_type = y_type,
+    .y_object = y_object,
+    .v_i = v_i,
+    .env = env
+  };
+
+  *v_i = 0;
+  SEXP out = call_loop(&data, map2_exec, type, progress, n, names);
+  *v_i = 0;
+
+  return out;
+}
+
+SEXP pmap_impl(
+  SEXP l,
+  SEXP env,
+  SEXP ffi_type,
+  SEXP progress,
+  SEXP ffi_n,
+  SEXP names,
+  SEXP i
+) {
+  int n_prot = 0;
+
+  const SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  const int n = INTEGER_ELT(ffi_n, 0);
+  int* v_i = INTEGER(i);
+
+  char buf[32];
+
+  const int n_l = (int) Rf_xlength(l);
+  struct pmap_elt* v_l = (struct pmap_elt*) R_alloc(n_l, sizeof(struct pmap_elt));
+
+  // Build `pmap_elt`s!
+  for (int j = 0; j < n_l; ++j) {
+    // `l` is guaranteed to be a bare list at this point by `pmap()`
+    SEXP elt = VECTOR_ELT(l, j);
+
+    const bool elt_object = Rf_isObject(elt);
+    const SEXPTYPE elt_type = TYPEOF(elt);
+    const void* v_elt = elt_object ? NULL : vec_cbegin(elt, elt_type);
+
+    v_l[j].elt = elt;
+    v_l[j].v_elt = v_elt;
+    v_l[j].elt_type = elt_type;
+    v_l[j].elt_object = elt_object;
+
+    // `.l_{elt}_i`
+    snprintf(buf, sizeof(buf), ".l_%d_i", j + 1);
+    v_l[j].sym_elt_i = Rf_install(buf);
+
+    // `.l_{elt}[[i]]`, with `elt` installed as `.l_{elt}` in `env`.
+    // Only used when `elt_object` is true, but we always set it up for simplicity.
+    snprintf(buf, sizeof(buf), ".l_%d", j + 1);
+    SEXP sym_elt = Rf_install(buf);
+    Rf_defineVar(sym_elt, elt, env);
+    v_l[j].call_elt_subset2_i = PROTECT_N(Rf_lang3(R_Bracket2Symbol, sym_elt, sym_i), &n_prot);
+  }
+
+  // Construct call like `f(.l_1_i, .l_2_i, ...l_{elt}_i, ...)`
   //
   // We construct the call backwards because can only add to the front of a
   // linked list. That makes PROTECTion tricky because we need to update it
   // each time to point to the start of the linked list.
-  SEXP l_sym = Rf_install(".l");
-  SEXP f_sym = Rf_install(".f");
-  SEXP i_sym = Rf_install("i");
+  SEXP call_pmap = Rf_lang1(R_DotsSymbol);
+  PROTECT_INDEX call_pmap_pi;
+  PROTECT_WITH_INDEX(call_pmap, &call_pmap_pi);
+  ++n_prot;
 
-  SEXP call = Rf_lang1(R_DotsSymbol);
-  PROTECT_INDEX call_shelter;
-  PROTECT_WITH_INDEX(call, &call_shelter);
-
-  bool has_call_names = call_names != R_NilValue;
+  SEXP call_names = PROTECT_N(Rf_getAttrib(l, R_NamesSymbol), &n_prot);
+  const bool has_call_names = call_names != R_NilValue;
   const SEXP* v_call_names = has_call_names ? STRING_PTR_RO(call_names) : NULL;
-  int call_n = INTEGER_ELT(ffi_call_n, 0);
 
-  for (int j = call_n - 1; j >= 0; --j) {
-    // Construct call like .l[[j]][[i]]
-    SEXP j_val = PROTECT(Rf_ScalarInteger(j + 1));
-    SEXP l_j_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, l_sym, j_val));
-    SEXP l_j_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, l_j_sym, i_sym));
-
-    call = Rf_lcons(l_j_i_sym, call);
-    REPROTECT(call, call_shelter);
+  for (int j = n_l - 1; j >= 0; --j) {
+    call_pmap = Rf_lcons(v_l[j].sym_elt_i, call_pmap);
+    REPROTECT(call_pmap, call_pmap_pi);
 
     if (has_call_names) {
       const char* call_name = CHAR(v_call_names[j]);
 
       if (call_name[0] != '\0') {
-        SET_TAG(call, Rf_install(call_name));
+        SET_TAG(call_pmap, Rf_install(call_name));
       }
     }
-
-    UNPROTECT(3);
   }
 
-  call = Rf_lcons(f_sym, call);
-  REPROTECT(call, call_shelter);
+  call_pmap = Rf_lcons(sym_dot_f, call_pmap);
+  REPROTECT(call_pmap, call_pmap_pi);
 
-  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
-  int n = INTEGER_ELT(ffi_n, 0);
-  int* p_i = INTEGER(i);
-  int force = call_n;
+  const struct pmap_exec_data data = (struct pmap_exec_data) {
+    .v_l = v_l,
+    .n_l = n_l,
+    .call_pmap = call_pmap,
+    .force_pmap = n_l,
+    .v_i = v_i,
+    .env = env
+  };
 
-  SEXP out = call_loop(
-    env,
-    call,
-    type,
-    progress,
-    n,
-    names,
-    p_i,
-    force
-  );
+  *v_i = 0;
+  SEXP out = call_loop(&data, pmap_exec, type, progress, n, names);
+  *v_i = 0;
 
-  UNPROTECT(1);
+  UNPROTECT(n_prot);
   return out;
+}
+
+void map_init(void) {
+  sym_i = Rf_install("i");
+  sym_dot_f = Rf_install(".f");
+  sym_dot_x = Rf_install(".x");
+  sym_dot_y = Rf_install(".y");
+  sym_dot_x_i = Rf_install(".x_i");
+  sym_dot_y_i = Rf_install(".y_i");
+
+  // `.x[[i]]`
+  call_dot_x_subset2_i = Rf_lang3(R_Bracket2Symbol, sym_dot_x, sym_i);
+  R_PreserveObject(call_dot_x_subset2_i);
+
+  // `.y[[i]]`
+  call_dot_y_subset2_i = Rf_lang3(R_Bracket2Symbol, sym_dot_y, sym_i);
+  R_PreserveObject(call_dot_y_subset2_i);
+
+  // `.f(.x_i, ...)`
+  call_map = Rf_lang3(sym_dot_f, sym_dot_x_i, R_DotsSymbol);
+  R_PreserveObject(call_map);
+
+  // `.f(.x_i, .y_i, ...)`
+  call_map2 = Rf_lang4(sym_dot_f, sym_dot_x_i, sym_dot_y_i, R_DotsSymbol);
+  R_PreserveObject(call_map2);
 }

--- a/src/map.c
+++ b/src/map.c
@@ -18,8 +18,8 @@ static SEXP sym_dot_y = NULL;
 static SEXP call_dot_x_subset2_i = NULL;
 static SEXP call_dot_y_subset2_i = NULL;
 
-static int force_map = 1;
-static int force_map2 = 2;
+static int force_map = 0;
+static int force_map2 = 0;
 
 static inline bool has_dots(SEXP env) {
   SEXP dots = Rf_findVarInFrame(env, R_DotsSymbol);
@@ -38,6 +38,33 @@ static inline SEXP as_call_arg(SEXP x, int* n_prot) {
   }
 }
 
+static inline void set_map_value(
+  SEXP out,
+  void* v_out,
+  SEXPTYPE type,
+  int i,
+  SEXP value
+) {
+  if (type == VECSXP) {
+    SET_VECTOR_ELT(out, i, value);
+    return;
+  }
+
+  if (TYPEOF(value) != type) {
+    set_vector_value(out, i, value, 0);
+    return;
+  }
+
+  switch (type) {
+  case LGLSXP: ((int*) v_out)[i] = LOGICAL_ELT(value, 0); break;
+  case INTSXP: ((int*) v_out)[i] = INTEGER_ELT(value, 0); break;
+  case REALSXP: ((double*) v_out)[i] = REAL_ELT(value, 0); break;
+  case STRSXP: SET_STRING_ELT(out, i, STRING_ELT(value, 0)); break;
+  case RAWSXP: RAW(out)[i] = RAW(value)[0]; break;
+  default: set_vector_value(out, i, value, 0);
+  }
+}
+
 static void cb_progress_done(void* bar_ptr) {
   SEXP bar = (SEXP)bar_ptr;
   cli_progress_done(bar);
@@ -52,32 +79,45 @@ static inline SEXP call_loop(
   int n,
   SEXP names
 ) {
-  SEXP bar = cli_progress_bar(n, progress);
-  R_PreserveObject(bar);
-  r_call_on_exit((void (*)(void*)) cb_progress_done, (void*) bar);
+  const bool use_progress = !(
+    TYPEOF(progress) == LGLSXP &&
+    Rf_xlength(progress) == 1 &&
+    LOGICAL_ELT(progress, 0) == 0
+  );
+  SEXP bar = R_NilValue;
+
+  if (use_progress) {
+    bar = cli_progress_bar(n, progress);
+    R_PreserveObject(bar);
+    r_call_on_exit((void (*)(void*)) cb_progress_done, (void*) bar);
+  }
 
   SEXP out = PROTECT(Rf_allocVector(type, n));
   Rf_setAttrib(out, R_NamesSymbol, names);
+  void* v_out = type == VECSXP ? NULL : DATAPTR(out);
 
   for (int i = 0; i < n; ++i) {
-    if (CLI_SHOULD_TICK) {
+    if (use_progress && CLI_SHOULD_TICK) {
       cli_progress_set(bar, i);
     }
     if (i % 1024 == 0) {
       R_CheckUserInterrupt();
     }
 
-    SEXP res = PROTECT(fn_exec(p_data, i));
-
-    if (type != VECSXP && Rf_length(res) != 1) {
-      Rf_errorcall(R_NilValue, "Result must be length 1, not %i.", Rf_length(res));
-    }
+    SEXP res = fn_exec(p_data, i);
 
     if (type == VECSXP) {
       SET_VECTOR_ELT(out, i, res);
-    } else {
-      set_vector_value(out, i, res, 0);
+      continue;
     }
+
+    PROTECT(res);
+
+    if (Rf_length(res) != 1) {
+      Rf_errorcall(R_NilValue, "Result must be length 1, not %i.", Rf_length(res));
+    }
+
+    set_map_value(out, v_out, type, i, res);
     UNPROTECT(1);
   }
 
@@ -90,6 +130,7 @@ struct map_exec_data {
   const void* v_x;
   SEXPTYPE x_type;
   bool x_object;
+  bool x_self_evaluating;
 
   SEXP call_arg;
   SEXP call;
@@ -102,11 +143,13 @@ struct map2_exec_data {
   const void* v_x;
   SEXPTYPE x_type;
   bool x_object;
+  bool x_self_evaluating;
 
   SEXP y;
   const void* v_y;
   SEXPTYPE y_type;
   bool y_object;
+  bool y_self_evaluating;
 
   SEXP call_x_arg;
   SEXP call_y_arg;
@@ -120,6 +163,7 @@ struct pmap_elt {
   const void* v_elt;
   SEXPTYPE elt_type;
   bool elt_object;
+  bool elt_self_evaluating;
 
   SEXP call_arg;
   // .l_{elt}[[i]]
@@ -147,7 +191,10 @@ static inline SEXP map_exec(const void* p_data_void, int i) {
   SEXP x_i = (p_data->x_object) ?
     Rf_eval(call_dot_x_subset2_i, p_data->env) :
     p_vec_get(p_data->v_x, p_data->x_type, i);
-  SETCAR(p_data->call_arg, as_call_arg(x_i, &n_prot));
+  SETCAR(
+    p_data->call_arg,
+    p_data->x_self_evaluating ? x_i : as_call_arg(x_i, &n_prot)
+  );
 
   SEXP out = R_forceAndCall(p_data->call, force_map, p_data->env);
   UNPROTECT(n_prot);
@@ -163,12 +210,18 @@ static inline SEXP map2_exec(const void* p_data_void, int i) {
   SEXP x_i = (p_data->x_object) ?
     Rf_eval(call_dot_x_subset2_i, p_data->env) :
     p_vec_get(p_data->v_x, p_data->x_type, i);
-  SETCAR(p_data->call_x_arg, as_call_arg(x_i, &n_prot));
+  SETCAR(
+    p_data->call_x_arg,
+    p_data->x_self_evaluating ? x_i : as_call_arg(x_i, &n_prot)
+  );
 
   SEXP y_i = (p_data->y_object) ?
     Rf_eval(call_dot_y_subset2_i, p_data->env) :
     p_vec_get(p_data->v_y, p_data->y_type, i);
-  SETCAR(p_data->call_y_arg, as_call_arg(y_i, &n_prot));
+  SETCAR(
+    p_data->call_y_arg,
+    p_data->y_self_evaluating ? y_i : as_call_arg(y_i, &n_prot)
+  );
 
   SEXP out = R_forceAndCall(p_data->call, force_map2, p_data->env);
   UNPROTECT(n_prot);
@@ -187,7 +240,10 @@ static inline SEXP pmap_exec(const void* p_data_void, int i) {
     SEXP elt_i = (p_elt->elt_object) ?
       Rf_eval(p_elt->call_elt_subset2_i, p_data->env) :
       p_vec_get(p_elt->v_elt, p_elt->elt_type, i);
-    SETCAR(p_elt->call_arg, as_call_arg(elt_i, &n_prot));
+    SETCAR(
+      p_elt->call_arg,
+      p_elt->elt_self_evaluating ? elt_i : as_call_arg(elt_i, &n_prot)
+    );
   }
 
   SEXP out = R_forceAndCall(p_data->call_pmap, p_data->force_pmap, p_data->env);
@@ -212,15 +268,18 @@ SEXP map_impl(
   const SEXPTYPE x_type = TYPEOF(x);
   const void* v_x = x_object ? NULL : vec_cbegin(x, x_type);
 
+  SEXP f = PROTECT(Rf_eval(sym_dot_f, env));
+
   SEXP call = PROTECT(has_dots(env) ?
-    Rf_lang3(sym_dot_f, R_NilValue, R_DotsSymbol) :
-    Rf_lang2(sym_dot_f, R_NilValue));
+    Rf_lang3(f, R_NilValue, R_DotsSymbol) :
+    Rf_lang2(f, R_NilValue));
 
   const struct map_exec_data data = (struct map_exec_data) {
     .x = x,
     .v_x = v_x,
     .x_type = x_type,
     .x_object = x_object,
+    .x_self_evaluating = !x_object && x_type != VECSXP,
     .call_arg = CDR(call),
     .call = call,
     .v_i = v_i,
@@ -231,7 +290,7 @@ SEXP map_impl(
   SEXP out = call_loop(&data, map_exec, type, progress, n, names);
   *v_i = 0;
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return out;
 }
 
@@ -257,19 +316,23 @@ SEXP map2_impl(
   const SEXPTYPE y_type = TYPEOF(y);
   const void* v_y = y_object ? NULL : vec_cbegin(y, y_type);
 
+  SEXP f = PROTECT(Rf_eval(sym_dot_f, env));
+
   SEXP call = PROTECT(has_dots(env) ?
-    Rf_lang4(sym_dot_f, R_NilValue, R_NilValue, R_DotsSymbol) :
-    Rf_lang3(sym_dot_f, R_NilValue, R_NilValue));
+    Rf_lang4(f, R_NilValue, R_NilValue, R_DotsSymbol) :
+    Rf_lang3(f, R_NilValue, R_NilValue));
 
   const struct map2_exec_data data = (struct map2_exec_data) {
     .x = x,
     .v_x = v_x,
     .x_type = x_type,
     .x_object = x_object,
+    .x_self_evaluating = !x_object && x_type != VECSXP,
     .y = y,
     .v_y = v_y,
     .y_type = y_type,
     .y_object = y_object,
+    .y_self_evaluating = !y_object && y_type != VECSXP,
     .call_x_arg = CDR(call),
     .call_y_arg = CDDR(call),
     .call = call,
@@ -281,7 +344,7 @@ SEXP map2_impl(
   SEXP out = call_loop(&data, map2_exec, type, progress, n, names);
   *v_i = 0;
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return out;
 }
 
@@ -305,6 +368,8 @@ SEXP pmap_impl(
   const int n_l = (int) Rf_xlength(l);
   struct pmap_elt* v_l = (struct pmap_elt*) R_alloc(n_l, sizeof(struct pmap_elt));
 
+  SEXP f = PROTECT_N(Rf_eval(sym_dot_f, env), &n_prot);
+
   // Build `pmap_elt`s!
   for (int j = 0; j < n_l; ++j) {
     // `l` is guaranteed to be a bare list at this point by `pmap()`
@@ -318,6 +383,7 @@ SEXP pmap_impl(
     v_l[j].v_elt = v_elt;
     v_l[j].elt_type = elt_type;
     v_l[j].elt_object = elt_object;
+    v_l[j].elt_self_evaluating = !elt_object && elt_type != VECSXP;
 
     // For objects, use `[[` to preserve dispatch. Install the object as
     // `.l_{elt}` and construct `.l_{elt}[[i]]`.
@@ -358,14 +424,14 @@ SEXP pmap_impl(
     }
   }
 
-  call_pmap = Rf_lcons(sym_dot_f, call_pmap);
+  call_pmap = Rf_lcons(f, call_pmap);
   REPROTECT(call_pmap, call_pmap_pi);
 
   const struct pmap_exec_data data = (struct pmap_exec_data) {
     .v_l = v_l,
     .n_l = n_l,
     .call_pmap = call_pmap,
-    .force_pmap = n_l,
+    .force_pmap = 0,
     .v_i = v_i,
     .env = env
   };

--- a/src/map.c
+++ b/src/map.c
@@ -14,17 +14,29 @@ static SEXP sym_i = NULL;
 static SEXP sym_dot_f = NULL;
 static SEXP sym_dot_x = NULL;
 static SEXP sym_dot_y = NULL;
-static SEXP sym_dot_x_i = NULL;
-static SEXP sym_dot_y_i = NULL;
 
 static SEXP call_dot_x_subset2_i = NULL;
 static SEXP call_dot_y_subset2_i = NULL;
 
-static SEXP call_map = NULL;
-static SEXP call_map2 = NULL;
-
 static int force_map = 1;
 static int force_map2 = 2;
+
+static inline bool has_dots(SEXP env) {
+  SEXP dots = Rf_findVarInFrame(env, R_DotsSymbol);
+  return dots != R_MissingArg && dots != R_NilValue;
+}
+
+static inline SEXP as_call_arg(SEXP x, int* n_prot) {
+  switch (TYPEOF(x)) {
+  case SYMSXP:
+    return PROTECT_N(Rf_lang2(R_QuoteSymbol, x), n_prot);
+  case LANGSXP:
+    PROTECT_N(x, n_prot);
+    return PROTECT_N(Rf_lang2(R_QuoteSymbol, x), n_prot);
+  default:
+    return x;
+  }
+}
 
 static void cb_progress_done(void* bar_ptr) {
   SEXP bar = (SEXP)bar_ptr;
@@ -61,7 +73,11 @@ static inline SEXP call_loop(
       Rf_errorcall(R_NilValue, "Result must be length 1, not %i.", Rf_length(res));
     }
 
-    set_vector_value(out, i, res, 0);
+    if (type == VECSXP) {
+      SET_VECTOR_ELT(out, i, res);
+    } else {
+      set_vector_value(out, i, res, 0);
+    }
     UNPROTECT(1);
   }
 
@@ -75,6 +91,8 @@ struct map_exec_data {
   SEXPTYPE x_type;
   bool x_object;
 
+  SEXP call_arg;
+  SEXP call;
   int* v_i;
   SEXP env;
 };
@@ -90,6 +108,9 @@ struct map2_exec_data {
   SEXPTYPE y_type;
   bool y_object;
 
+  SEXP call_x_arg;
+  SEXP call_y_arg;
+  SEXP call;
   int* v_i;
   SEXP env;
 };
@@ -100,8 +121,7 @@ struct pmap_elt {
   SEXPTYPE elt_type;
   bool elt_object;
 
-  // .l_{elt}_i
-  SEXP sym_elt_i;
+  SEXP call_arg;
   // .l_{elt}[[i]]
   SEXP call_elt_subset2_i;
 };
@@ -120,37 +140,44 @@ struct pmap_exec_data {
 
 static inline SEXP map_exec(const void* p_data_void, int i) {
   const struct map_exec_data* p_data = (const struct map_exec_data*) p_data_void;
+  int n_prot = 0;
 
   *p_data->v_i = i + 1;
 
   SEXP x_i = (p_data->x_object) ?
     Rf_eval(call_dot_x_subset2_i, p_data->env) :
     p_vec_get(p_data->v_x, p_data->x_type, i);
-  Rf_defineVar(sym_dot_x_i, x_i, p_data->env);
+  SETCAR(p_data->call_arg, as_call_arg(x_i, &n_prot));
 
-  return R_forceAndCall(call_map, force_map, p_data->env);
+  SEXP out = R_forceAndCall(p_data->call, force_map, p_data->env);
+  UNPROTECT(n_prot);
+  return out;
 }
 
 static inline SEXP map2_exec(const void* p_data_void, int i) {
   const struct map2_exec_data* p_data = (const struct map2_exec_data*) p_data_void;
+  int n_prot = 0;
 
   *p_data->v_i = i + 1;
 
   SEXP x_i = (p_data->x_object) ?
     Rf_eval(call_dot_x_subset2_i, p_data->env) :
     p_vec_get(p_data->v_x, p_data->x_type, i);
-  Rf_defineVar(sym_dot_x_i, x_i, p_data->env);
+  SETCAR(p_data->call_x_arg, as_call_arg(x_i, &n_prot));
 
   SEXP y_i = (p_data->y_object) ?
     Rf_eval(call_dot_y_subset2_i, p_data->env) :
     p_vec_get(p_data->v_y, p_data->y_type, i);
-  Rf_defineVar(sym_dot_y_i, y_i, p_data->env);
+  SETCAR(p_data->call_y_arg, as_call_arg(y_i, &n_prot));
 
-  return R_forceAndCall(call_map2, force_map2, p_data->env);
+  SEXP out = R_forceAndCall(p_data->call, force_map2, p_data->env);
+  UNPROTECT(n_prot);
+  return out;
 }
 
 static inline SEXP pmap_exec(const void* p_data_void, int i) {
   const struct pmap_exec_data* p_data = (const struct pmap_exec_data*) p_data_void;
+  int n_prot = 0;
 
   *p_data->v_i = i + 1;
 
@@ -160,10 +187,12 @@ static inline SEXP pmap_exec(const void* p_data_void, int i) {
     SEXP elt_i = (p_elt->elt_object) ?
       Rf_eval(p_elt->call_elt_subset2_i, p_data->env) :
       p_vec_get(p_elt->v_elt, p_elt->elt_type, i);
-    Rf_defineVar(p_elt->sym_elt_i, elt_i, p_data->env);
+    SETCAR(p_elt->call_arg, as_call_arg(elt_i, &n_prot));
   }
 
-  return R_forceAndCall(p_data->call_pmap, p_data->force_pmap, p_data->env);
+  SEXP out = R_forceAndCall(p_data->call_pmap, p_data->force_pmap, p_data->env);
+  UNPROTECT(n_prot);
+  return out;
 }
 
 SEXP map_impl(
@@ -183,11 +212,17 @@ SEXP map_impl(
   const SEXPTYPE x_type = TYPEOF(x);
   const void* v_x = x_object ? NULL : vec_cbegin(x, x_type);
 
+  SEXP call = PROTECT(has_dots(env) ?
+    Rf_lang3(sym_dot_f, R_NilValue, R_DotsSymbol) :
+    Rf_lang2(sym_dot_f, R_NilValue));
+
   const struct map_exec_data data = (struct map_exec_data) {
     .x = x,
     .v_x = v_x,
     .x_type = x_type,
     .x_object = x_object,
+    .call_arg = CDR(call),
+    .call = call,
     .v_i = v_i,
     .env = env
   };
@@ -196,6 +231,7 @@ SEXP map_impl(
   SEXP out = call_loop(&data, map_exec, type, progress, n, names);
   *v_i = 0;
 
+  UNPROTECT(1);
   return out;
 }
 
@@ -221,6 +257,10 @@ SEXP map2_impl(
   const SEXPTYPE y_type = TYPEOF(y);
   const void* v_y = y_object ? NULL : vec_cbegin(y, y_type);
 
+  SEXP call = PROTECT(has_dots(env) ?
+    Rf_lang4(sym_dot_f, R_NilValue, R_NilValue, R_DotsSymbol) :
+    Rf_lang3(sym_dot_f, R_NilValue, R_NilValue));
+
   const struct map2_exec_data data = (struct map2_exec_data) {
     .x = x,
     .v_x = v_x,
@@ -230,6 +270,9 @@ SEXP map2_impl(
     .v_y = v_y,
     .y_type = y_type,
     .y_object = y_object,
+    .call_x_arg = CDR(call),
+    .call_y_arg = CDDR(call),
+    .call = call,
     .v_i = v_i,
     .env = env
   };
@@ -238,6 +281,7 @@ SEXP map2_impl(
   SEXP out = call_loop(&data, map2_exec, type, progress, n, names);
   *v_i = 0;
 
+  UNPROTECT(1);
   return out;
 }
 
@@ -275,24 +319,23 @@ SEXP pmap_impl(
     v_l[j].elt_type = elt_type;
     v_l[j].elt_object = elt_object;
 
-    // `.l_{elt}_i`
-    snprintf(buf, sizeof(buf), ".l_%d_i", j + 1);
-    v_l[j].sym_elt_i = Rf_install(buf);
-
-    // `.l_{elt}[[i]]`, with `elt` installed as `.l_{elt}` in `env`.
-    // Only used when `elt_object` is true, but we always set it up for simplicity.
+    // For objects, use `[[` to preserve dispatch. Install the object as
+    // `.l_{elt}` and construct `.l_{elt}[[i]]`.
     snprintf(buf, sizeof(buf), ".l_%d", j + 1);
     SEXP sym_elt = Rf_install(buf);
     Rf_defineVar(sym_elt, elt, env);
-    v_l[j].call_elt_subset2_i = PROTECT_N(Rf_lang3(R_Bracket2Symbol, sym_elt, sym_i), &n_prot);
+    v_l[j].call_elt_subset2_i = PROTECT_N(
+      Rf_lang3(R_Bracket2Symbol, sym_elt, sym_i),
+      &n_prot
+    );
   }
 
-  // Construct call like `f(.l_1_i, .l_2_i, ...l_{elt}_i, ...)`
+  // Construct a call whose argument cells are updated on each iteration.
   //
   // We construct the call backwards because can only add to the front of a
   // linked list. That makes PROTECTion tricky because we need to update it
   // each time to point to the start of the linked list.
-  SEXP call_pmap = Rf_lang1(R_DotsSymbol);
+  SEXP call_pmap = has_dots(env) ? Rf_lang1(R_DotsSymbol) : R_NilValue;
   PROTECT_INDEX call_pmap_pi;
   PROTECT_WITH_INDEX(call_pmap, &call_pmap_pi);
   ++n_prot;
@@ -302,8 +345,9 @@ SEXP pmap_impl(
   const SEXP* v_call_names = has_call_names ? STRING_PTR_RO(call_names) : NULL;
 
   for (int j = n_l - 1; j >= 0; --j) {
-    call_pmap = Rf_lcons(v_l[j].sym_elt_i, call_pmap);
+    call_pmap = Rf_lcons(R_NilValue, call_pmap);
     REPROTECT(call_pmap, call_pmap_pi);
+    v_l[j].call_arg = call_pmap;
 
     if (has_call_names) {
       const char* call_name = CHAR(v_call_names[j]);
@@ -339,8 +383,6 @@ void map_init(void) {
   sym_dot_f = Rf_install(".f");
   sym_dot_x = Rf_install(".x");
   sym_dot_y = Rf_install(".y");
-  sym_dot_x_i = Rf_install(".x_i");
-  sym_dot_y_i = Rf_install(".y_i");
 
   // `.x[[i]]`
   call_dot_x_subset2_i = Rf_lang3(R_Bracket2Symbol, sym_dot_x, sym_i);
@@ -350,11 +392,4 @@ void map_init(void) {
   call_dot_y_subset2_i = Rf_lang3(R_Bracket2Symbol, sym_dot_y, sym_i);
   R_PreserveObject(call_dot_y_subset2_i);
 
-  // `.f(.x_i, ...)`
-  call_map = Rf_lang3(sym_dot_f, sym_dot_x_i, R_DotsSymbol);
-  R_PreserveObject(call_map);
-
-  // `.f(.x_i, .y_i, ...)`
-  call_map2 = Rf_lang4(sym_dot_f, sym_dot_x_i, sym_dot_y_i, R_DotsSymbol);
-  R_PreserveObject(call_map2);
 }

--- a/src/map.h
+++ b/src/map.h
@@ -2,21 +2,25 @@
 #define MAP_H
 
 extern "C" {
-  SEXP map_impl(SEXP env,
-                SEXP ffi_type,
-                SEXP progress,
-                SEXP ffi_n,
-                SEXP names,
-                SEXP i);
+  SEXP map_impl(
+    SEXP x,
+    SEXP env,
+    SEXP ffi_type,
+    SEXP progress,
+    SEXP ffi_n,
+    SEXP names,
+    SEXP i
+  );
 
-  SEXP pmap_impl(SEXP env,
-                 SEXP ffi_type,
-                 SEXP progress,
-                 SEXP ffi_n,
-                 SEXP names,
-                 SEXP i,
-                 SEXP call_names,
-                 SEXP ffi_call_n);
+  SEXP pmap_impl(
+    SEXP l,
+    SEXP env,
+    SEXP ffi_type,
+    SEXP progress,
+    SEXP ffi_n,
+    SEXP names,
+    SEXP i
+  );
 }
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,12 @@
  SEXP R_getVar(SEXP symbol, SEXP rho, Rboolean inherits);
 #endif
 
+#if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
+static inline const SEXP* VECTOR_PTR_RO(SEXP x) {
+  return (const SEXP*) DATAPTR_RO(x);
+}
+#endif
+
 SEXP sym_protect(SEXP x);
 
 bool is_vector(SEXP x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <Rversion.h>
 
+#define PROTECT_N(x, n) (++(*n), PROTECT(x))
 
 #if (defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0))
  SEXP R_getVarEx(SEXP symbol, SEXP rho, Rboolean inherits, SEXP ifnotfound);
@@ -17,5 +18,30 @@ bool is_vector(SEXP x);
 SEXP lang7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y);
 SEXP lang8(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y, SEXP z);
 
+static inline const void* vec_cbegin(SEXP x, SEXPTYPE type) {
+  switch (type) {
+    case LGLSXP: return LOGICAL_RO(x);
+    case INTSXP: return INTEGER_RO(x);
+    case REALSXP: return REAL_RO(x);
+    case CPLXSXP: return COMPLEX_RO(x);
+    case RAWSXP: return RAW_RO(x);
+    case STRSXP: return STRING_PTR_RO(x);
+    case VECSXP: return VECTOR_PTR_RO(x);
+    default: Rf_error("Unreachable");
+  }
+}
+
+static inline SEXP p_vec_get(const void* v_x, SEXPTYPE type, int i) {
+  switch (type) {
+    case LGLSXP: return Rf_ScalarLogical(((const int*) v_x)[i]);
+    case INTSXP: return Rf_ScalarInteger(((const int*) v_x)[i]);
+    case REALSXP: return Rf_ScalarReal(((const double*) v_x)[i]);
+    case CPLXSXP: return Rf_ScalarComplex(((const Rcomplex*) v_x)[i]);
+    case RAWSXP: return Rf_ScalarRaw(((const Rbyte*) v_x)[i]);
+    case STRSXP: return Rf_ScalarString(((const SEXP*) v_x)[i]);
+    case VECSXP: return ((const SEXP*) v_x)[i];
+    default: Rf_error("Unreachable");
+  }
+}
 
 #endif

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -5,7 +5,7 @@ test_that("preserves names", {
 
 test_that("creates simple call", {
   out <- map(1, function(x) sys.call())[[1]]
-  expect_equal(out, quote(.f(.x_i, ...)))
+  expect_equal(out, quote(.f(1)))
 })
 
 test_that("fails on non-vectors", {

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -5,7 +5,7 @@ test_that("preserves names", {
 
 test_that("creates simple call", {
   out <- map(1, function(x) sys.call())[[1]]
-  expect_equal(out, quote(.f(.x[[i]], ...)))
+  expect_equal(out, quote(.f(.x_i, ...)))
 })
 
 test_that("fails on non-vectors", {
@@ -90,8 +90,16 @@ test_that("logical and integer NA become correct double NA", {
 })
 
 test_that("map forces arguments in same way as base R", {
+  x <- 1:2
   f_map <- map(1:2, function(i) function(x) x + i)
   f_base <- lapply(1:2, function(i) function(x) x + i)
+
+  expect_equal(f_map[[1]](0), f_base[[1]](0))
+  expect_equal(f_map[[2]](0), f_base[[2]](0))
+
+  x <- structure(1:2, class = "foo")
+  f_map <- map(x, function(i) function(x) x + i)
+  f_base <- lapply(x, function(i) function(x) x + i)
 
   expect_equal(f_map[[1]](0), f_base[[1]](0))
   expect_equal(f_map[[2]](0), f_base[[2]](0))

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -5,7 +5,8 @@ test_that("preserves names", {
 
 test_that("creates simple call", {
   out <- map(1, function(x) sys.call())[[1]]
-  expect_equal(out, quote(.f(1)))
+  expect_true(is.function(out[[1]]))
+  expect_equal(out[[2]], 1)
 })
 
 test_that("fails on non-vectors", {


### PR DESCRIPTION
## Summary

This reworks the C implementation of the `map()`, `map2()`, and `pmap()` families to remove repeated R evaluation and other per-element overhead while preserving S3 extraction, coercion, progress, interrupt, and indexed-error behavior.

## Changes and motivation

- Pass input vectors directly to the C implementations. Bare vectors are read through cached read-only data pointers; objects still use `[[` so S3/vctrs dispatch is preserved. This removes repeated evaluation of `.x[[i]]` and `.y[[i]]` in R.
- Build one reusable call per map invocation and update its argument cells directly. Symbols and language objects are quoted before insertion so they continue to be passed as data. This avoids per-element environment rebinding and symbol lookup.
- Omit `...` from the reusable call when it is empty. Empty dots previously incurred expansion overhead on every iteration.
- Resolve `.f` once and place the function directly in the reusable call. This avoids resolving the callback for every element.
- Allow mapped arguments to remain lazy. Because calls now contain the actual extracted values rather than references to a changing loop binding, callbacks can safely force only the arguments they use. This particularly helps `map2()` and `pmap()` callbacks that ignore some inputs.
- Skip all cli progress setup and volatile timer polling when `.progress = FALSE`. Explicit progress bars retain the existing path.
- Add direct output paths. List results go straight to `SET_VECTOR_ELT()` without redundant protection, and exact-type atomic results write through a cached output pointer. Results needing coercion retain `set_vector_value()`.
- Construct `pmap()` argument and S3 extraction machinery once per invocation rather than rebuilding nested subset calls per element.
- Add the `VECTOR_PTR_RO()` compatibility definition needed before R 4.5.

The internal call shown by `sys.call()` now contains the resolved function and mapped values. That representation is an implementation detail; the test now checks the meaningful call properties rather than its exact syntax.

## Performance

`bench::mark()` medians for 10,000 elements, compared with purrr 1.2.2 on R 4.5 / Apple arm64:

| Workload | purrr 1.2.2 | This PR | Improvement |
|---|---:|---:|---:|
| `map(list, identity)` | 1.669 ms | 1.003 ms | 40% |
| `map_int(integer, identity)` | 1.810 ms | 1.096 ms | 39% |
| `map_dbl(double, identity)` | 1.813 ms | 1.096 ms | 40% |
| `map2_int(integer, integer, add)` | 3.192 ms | 1.814 ms | 43% |
| two-argument `pmap_int()` | 4.187 ms | 1.856 ms | 56% |
| five-argument `pmap_int()` | 9.293 ms | 3.907 ms | 58% |

The first direct-extraction/call changes account for most of the gain. In isolated comparisons against that faster intermediate implementation, the later changes improve callbacks using only a subset of arguments by roughly 10–17%; callbacks forcing every argument improve by roughly 3–8%.

## Verification

- 1,032 tests pass.
- Existing coverage exercises symbolic inputs, retained closures, S3/vctrs extraction, coercion, dots forwarding, progress bars, interrupts, and indexed errors.
- `git diff --check` passes.
