### PR TITLE
Bump rlang to 1.3.0 and regenerate snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,9 +19,9 @@ Imports:
     cli (>= 3.6.1),
     lifecycle (>= 1.0.3),
     magrittr (>= 1.5.0),
-    rlang (>= 1.1.1),
+    rlang (>= 1.3.0),
     vctrs (>= 0.6.3)
-Suggests: 
+Suggests:
     carrier (>= 0.3.0),
     covr,
     dplyr (>= 0.7.8),

--- a/tests/testthat/_snaps/map.md
+++ b/tests/testthat/_snaps/map.md
@@ -69,7 +69,7 @@
       map_vec(1:2, ~ if (.x == 1) factor("x") else 1)
     Condition
       Error in `map_vec()`:
-      ! Can't combine `<list>[[1]]` <factor<bf275>> and `<list>[[2]]` <double>.
+      ! Can't combine `<list>[[1]]` <factor<9758a>> and `<list>[[2]]` <double>.
 
 # can enforce .ptype
 
@@ -77,5 +77,5 @@
       map_vec(1:2, ~ factor("x"), .ptype = integer())
     Condition
       Error in `map_vec()`:
-      ! Can't convert `<list>[[1]]` <factor<bf275>> to <integer>.
+      ! Can't convert `<list>[[1]]` <factor<9758a>> to <integer>.
 

--- a/tests/testthat/_snaps/parallel.md
+++ b/tests/testthat/_snaps/parallel.md
@@ -58,7 +58,7 @@
       map_vec(1:2, in_parallel(~ if (.x == 1) factor("x") else 1))
     Condition
       Error in `map_vec()`:
-      ! Can't combine `<list>[[1]]` <factor<bf275>> and `<list>[[2]]` <double>.
+      ! Can't combine `<list>[[1]]` <factor<9758a>> and `<list>[[2]]` <double>.
 
 # can enforce .ptype
 
@@ -66,7 +66,7 @@
       map_vec(1:2, in_parallel(~ factor("x")), .ptype = integer())
     Condition
       Error in `map_vec()`:
-      ! Can't convert `<list>[[1]]` <factor<bf275>> to <integer>.
+      ! Can't convert `<list>[[1]]` <factor<9758a>> to <integer>.
 
 # verifies result types and length
 


### PR DESCRIPTION
rlang 1.3.0 has a new version of `rlang::hash()` that is independent of R's serializer, but it means that we need to regenerate all snapshot tests that rely on that in some way. Here, that means some `factor<{hash}>` snapshots