### PR TITLE
Update docs for `in_parallel()` accepting existing functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* `in_parallel()` now accepts existing functions, so `.f` no longer needs to be defined inside the call, e.g. `in_parallel(sum)` or `in_parallel(fun, helper = helper)`.
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* `in_parallel()` is no longer experimental.
+
 * `in_parallel()` now accepts existing functions, so `.f` no longer needs to be defined inside the call, e.g. `in_parallel(sum)` or `in_parallel(fun, helper = helper)`.
 
 # purrr 1.2.2

--- a/R/imap.R
+++ b/R/imap.R
@@ -13,8 +13,6 @@
 #'   * A formula, e.g. `~ .x + .y`. Use `.x` to refer to the current element and
 #'     `.y` to refer to the current index. No longer recommended.
 #'
-#'   `r lifecycle::badge("experimental")`
-#'
 #'   Wrap a function with [in_parallel()] to declare that it should be performed
 #'   in parallel. See [in_parallel()] for more details.
 #'   Use of `...` is not permitted in this context.

--- a/R/map.R
+++ b/R/map.R
@@ -30,8 +30,6 @@
 #'     `\(x) pluck(x, "idx", 1)` respectively. Optionally supply `.default` to
 #'     set a default value if the indexed element is `NULL` or does not exist.
 #'
-#'   `r lifecycle::badge("experimental")`
-#'
 #'   Wrap a function with [in_parallel()] to declare that it should be performed
 #'   in parallel. See [in_parallel()] for more details.
 #'   Use of `...` is not permitted in this context.

--- a/R/map2.R
+++ b/R/map2.R
@@ -14,8 +14,6 @@
 #'     element of `x` and `.y` to refer to the current element of `y`.
 #'     No longer recommended.
 #'
-#'   `r lifecycle::badge("experimental")`
-#'
 #'   Wrap a function with [in_parallel()] to declare that it should be performed
 #'   in parallel. See [in_parallel()] for more details.
 #'   Use of `...` is not permitted in this context.

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -1,8 +1,6 @@
 #' Parallelization in purrr
 #'
 #' @description
-#' `r lifecycle::badge("experimental")`
-#'
 #' All map functions allow parallelized operation using \CRANpkg{mirai}.
 #'
 #' Wrap functions passed to the `.f` argument of [map()] and its variants with

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -22,9 +22,20 @@
 #' [mirai::require_daemons()] may be used to enforce the use of parallel
 #' processing. See the section 'Daemons settings' below.
 #'
-#' @param .f A fresh formula or function. "Fresh" here means that they should be
-#'   declared in the call to [in_parallel()].
+#' @param .f A function or formula. The function may be defined inside the
+#'   call to [in_parallel()] as an anonymous function, or be an existing
+#'   function. The following applies to existing functions:
+#'
+#'   * A plain function (closure) has its enclosing environment replaced with
+#'     the crate's evaluation environment, so any data it depends on must be
+#'     declared via `...`.
+#'   * A namespaced function (such as `stats::sd`) or a primitive function
+#'     (such as `sum`) is already self-contained and is used directly, with its
+#'     environment left untouched. Data declared via `...` would not be
+#'     reachable from such a function, so it is an error to supply any.
 #' @param ... Named arguments to declare in the environment of the function.
+#'   It is an error to supply `...` when `.f` is a namespaced or primitive
+#'   function, as declared data would not be reachable from such functions.
 #'
 #' @return A 'crate' (classed function).
 #'
@@ -36,17 +47,18 @@
 #'   within the function to attach a package to the search path, which allows
 #'   subsequent use of package functions without the explicit namespace.
 #'
-#' * They should declare any data they depend on. Declare data by supplying
-#'   named arguments to `...`. When `.f` is an anonymous function to a
-#'   locally-defined function of the form `\(x) fun(x)`, `fun` itself must be
-#'   supplied to `...` in the manner of: `in_parallel(\(x) fun(x), fun = fun)`.
+#' * They should declare any data they depend on by supplying named arguments
+#'   to `...`. When an existing function is passed to `.f` directly, only its
+#'   dependencies need to be declared, e.g. `in_parallel(fun, helper = helper)`.
+#'   When it is wrapped in an anonymous function such as `\(x) fun(x)`, `fun`
+#'   itself must also be declared: `in_parallel(\(x) fun(x), fun = fun)`.
 #'
 #' * Functions (closures) supplied to `...` must themselves be self-contained,
-#'   as they are modified to share the same closure as the main function. This
-#'   means that all helper functions and other required variables must also be
-#'   supplied as further `...` arguments. This applies only for functions
-#'   directly supplied to `...`: containers (such as lists) are not
-#'   recursively analysed. In other words, if you supply complex
+#'   as they are modified to share the same enclosing environment as the main
+#'   function. This means that all helper functions and other required
+#'   variables must also be supplied as further `...` arguments. This applies
+#'   only to functions directly supplied to `...`: containers (such as lists)
+#'   are not recursively analysed. In other words, if you supply complex
 #'   objects to `...` you're at risk of unexpectedly including large objects.
 #'
 #' [in_parallel()] is a simple wrapper of [carrier::crate()] and you may refer
@@ -54,12 +66,13 @@
 #'
 #' Example usage:
 #' ```r
-#' # The function needs to be freshly-defined, so instead of:
+#' # Package functions can be passed directly, including primitives such as
+#' # sum() and namespaced functions such as stats::sd():
 #' mtcars |> map_dbl(in_parallel(sum))
-#' # Use an anonymous function:
-#' mtcars |> map_dbl(in_parallel(\(x) sum(x)))
+#' mtcars |> map_dbl(in_parallel(stats::sd))
 #'
-#' # Package functions need to be explicitly namespaced, so instead of:
+#' # Functions you define yourself must call package functions with an
+#' # explicit `::` namespace, so instead of:
 #' map(1:3, in_parallel(\(x) vec_init(integer(), x)))
 #' # Use :: to namespace all package functions:
 #' map(1:3, in_parallel(\(x) vctrs::vec_init(integer(), x)))
@@ -67,11 +80,11 @@
 #' fun <- function(x) { param + helper(x) }
 #' helper <- function(x) { x %% 2 }
 #' param <- 5
-#' # Operating in parallel, locally-defined functions, including helper
-#' # functions and other objects required by it, will not be found:
-#' map(1:3, in_parallel(\(x) fun(x)))
+#' # A locally-defined function can be passed directly, but its environment is
+#' # set to that of the crate, so the objects it depends on will not be found:
+#' map(1:3, in_parallel(fun))
 #' # Use the ... argument to supply these objects:
-#' map(1:3, in_parallel(\(x) fun(x), fun = fun, helper = helper, param = param))
+#' map(1:3, in_parallel(fun, helper = helper, param = param))
 #' ```
 #'
 #' @section When to use:
@@ -155,7 +168,7 @@
 #'
 #' slow_lm <- function(formula, data) {
 #'   delay()
-#'   lm(formula, data)
+#'   stats::lm(formula, data)
 #' }
 #'
 #' # Example of a 'crate' returned by in_parallel(). The object print method

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -22,8 +22,6 @@
 #'     `function(x, y, z) x + y / z`
 #'   * A formula, e.g. `~ ..1 + ..2 / ..3`. No longer recommended.
 #'
-#'   `r lifecycle::badge("experimental")`
-#'
 #'   Wrap a function with [in_parallel()] to declare that it should be performed
 #'   in parallel. See [in_parallel()] for more details.
 #'   Use of `...` is not permitted in this context.

--- a/man/imap.Rd
+++ b/man/imap.Rd
@@ -36,8 +36,6 @@ iwalk(.x, .f, ...)
 \code{.y} to refer to the current index. No longer recommended.
 }
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}

--- a/man/in_parallel.Rd
+++ b/man/in_parallel.Rd
@@ -29,8 +29,6 @@ function, as declared data would not be reachable from such functions.}
 A 'crate' (classed function).
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 All map functions allow parallelized operation using \CRANpkg{mirai}.
 
 Wrap functions passed to the \code{.f} argument of \code{\link[=map]{map()}} and its variants with

--- a/man/in_parallel.Rd
+++ b/man/in_parallel.Rd
@@ -8,10 +8,22 @@
 in_parallel(.f, ...)
 }
 \arguments{
-\item{.f}{A fresh formula or function. "Fresh" here means that they should be
-declared in the call to \code{\link[=in_parallel]{in_parallel()}}.}
+\item{.f}{A function or formula. The function may be defined inside the
+call to \code{\link[=in_parallel]{in_parallel()}} as an anonymous function, or be an existing
+function. The following applies to existing functions:
+\itemize{
+\item A plain function (closure) has its enclosing environment replaced with
+the crate's evaluation environment, so any data it depends on must be
+declared via \code{...}.
+\item A namespaced function (such as \code{stats::sd}) or a primitive function
+(such as \code{sum}) is already self-contained and is used directly, with its
+environment left untouched. Data declared via \code{...} would not be
+reachable from such a function, so it is an error to supply any.
+}}
 
-\item{...}{Named arguments to declare in the environment of the function.}
+\item{...}{Named arguments to declare in the environment of the function.
+It is an error to supply \code{...} when \code{.f} is a namespaced or primitive
+function, as declared data would not be reachable from such functions.}
 }
 \value{
 A 'crate' (classed function).
@@ -48,16 +60,17 @@ instance \code{ggplot()} from the ggplot2 package must be called with its
 namespace prefix: \code{ggplot2::ggplot()}. An alternative is to use \code{library()}
 within the function to attach a package to the search path, which allows
 subsequent use of package functions without the explicit namespace.
-\item They should declare any data they depend on. Declare data by supplying
-named arguments to \code{...}. When \code{.f} is an anonymous function to a
-locally-defined function of the form \verb{\\(x) fun(x)}, \code{fun} itself must be
-supplied to \code{...} in the manner of: \verb{in_parallel(\\(x) fun(x), fun = fun)}.
+\item They should declare any data they depend on by supplying named arguments
+to \code{...}. When an existing function is passed to \code{.f} directly, only its
+dependencies need to be declared, e.g. \code{in_parallel(fun, helper = helper)}.
+When it is wrapped in an anonymous function such as \verb{\\(x) fun(x)}, \code{fun}
+itself must also be declared: \verb{in_parallel(\\(x) fun(x), fun = fun)}.
 \item Functions (closures) supplied to \code{...} must themselves be self-contained,
-as they are modified to share the same closure as the main function. This
-means that all helper functions and other required variables must also be
-supplied as further \code{...} arguments. This applies only for functions
-directly supplied to \code{...}: containers (such as lists) are not
-recursively analysed. In other words, if you supply complex
+as they are modified to share the same enclosing environment as the main
+function. This means that all helper functions and other required
+variables must also be supplied as further \code{...} arguments. This applies
+only to functions directly supplied to \code{...}: containers (such as lists)
+are not recursively analysed. In other words, if you supply complex
 objects to \code{...} you're at risk of unexpectedly including large objects.
 }
 
@@ -66,12 +79,13 @@ to that package for more details.
 
 Example usage:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{# The function needs to be freshly-defined, so instead of:
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Package functions can be passed directly, including primitives such as
+# sum() and namespaced functions such as stats::sd():
 mtcars |> map_dbl(in_parallel(sum))
-# Use an anonymous function:
-mtcars |> map_dbl(in_parallel(\\(x) sum(x)))
+mtcars |> map_dbl(in_parallel(stats::sd))
 
-# Package functions need to be explicitly namespaced, so instead of:
+# Functions you define yourself must call package functions with an
+# explicit `::` namespace, so instead of:
 map(1:3, in_parallel(\\(x) vec_init(integer(), x)))
 # Use :: to namespace all package functions:
 map(1:3, in_parallel(\\(x) vctrs::vec_init(integer(), x)))
@@ -79,11 +93,11 @@ map(1:3, in_parallel(\\(x) vctrs::vec_init(integer(), x)))
 fun <- function(x) \{ param + helper(x) \}
 helper <- function(x) \{ x \%\% 2 \}
 param <- 5
-# Operating in parallel, locally-defined functions, including helper
-# functions and other objects required by it, will not be found:
-map(1:3, in_parallel(\\(x) fun(x)))
+# A locally-defined function can be passed directly, but its environment is
+# set to that of the crate, so the objects it depends on will not be found:
+map(1:3, in_parallel(fun))
 # Use the ... argument to supply these objects:
-map(1:3, in_parallel(\\(x) fun(x), fun = fun, helper = helper, param = param))
+map(1:3, in_parallel(fun, helper = helper, param = param))
 }\if{html}{\out{</div>}}
 }
 
@@ -164,7 +178,7 @@ delay <- function(secs = default_param) {
 
 slow_lm <- function(formula, data) {
   delay()
-  lm(formula, data)
+  stats::lm(formula, data)
 }
 
 # Example of a 'crate' returned by in_parallel(). The object print method

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -39,8 +39,6 @@ are shorthand for \verb{\\(x) pluck(x, "idx")}, \verb{\\(x) pluck(x, 1)}, and
 set a default value if the indexed element is \code{NULL} or does not exist.
 }
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}

--- a/man/map2.Rd
+++ b/man/map2.Rd
@@ -37,8 +37,6 @@ element of \code{x} and \code{.y} to refer to the current element of \code{y}.
 No longer recommended.
 }
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}

--- a/man/map_depth.Rd
+++ b/man/map_depth.Rd
@@ -32,8 +32,6 @@ are shorthand for \verb{\\(x) pluck(x, "idx")}, \verb{\\(x) pluck(x, 1)}, and
 set a default value if the indexed element is \code{NULL} or does not exist.
 }
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}

--- a/man/map_if.Rd
+++ b/man/map_if.Rd
@@ -31,8 +31,6 @@ are shorthand for \verb{\\(x) pluck(x, "idx")}, \verb{\\(x) pluck(x, 1)}, and
 set a default value if the indexed element is \code{NULL} or does not exist.
 }
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}

--- a/man/pmap.Rd
+++ b/man/pmap.Rd
@@ -43,8 +43,6 @@ to be called once for each row.}
 \item A formula, e.g. \code{~ ..1 + ..2 / ..3}. No longer recommended.
 }
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}


### PR DESCRIPTION
These are pure docs updates in light of https://github.com/r-lib/carrier/pull/37 we merged at carrier. With this, I think we can take `in_parallel()` out of experimental status.

I'll update the dependency versions in a separate PR once carrier is released on CRAN.